### PR TITLE
DM-41683: Support ad-hoc pytest args in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test:
 	export CM_DATABASE_SCHEMA=cm_service_test && \
 	export CM_ARQ_REDIS_URL=redis://localhost:$${CM_ARQ_REDIS_PORT}/1 && \
 	export CM_ARQ_REDIS_PASSWORD=INSECURE-PASSWORD && \
-	pytest -vvv --cov=lsst.cmservice --cov-branch --cov-report=term --cov-report=html
+	pytest -vvv --cov=lsst.cmservice --cov-branch --cov-report=term --cov-report=html ${PYTEST_ARGS}
 
 .PHONY: run
 run:


### PR DESCRIPTION
Adds the ability to say, e.g.:

```PYTEST_ARGS="-k test_error_match.py" make test```

This is convenient for example to restrict `pytest` runs to particular test during test development debug, while still being able to get all the required magic env vars and `pytest-coverage` arguments via `make test`.