### PR TITLE
DM-42064: cm-service, cheat mode script retry

### DIFF
--- a/src/lsst/cmservice/cli/commands.py
+++ b/src/lsst/cmservice/cli/commands.py
@@ -892,6 +892,29 @@ def process(
 @action.command()
 @options.cmclient()
 @options.fullname()
+@options.status()
+@options.output()
+def reset_script(
+    client: CMClient,
+    fullname: options.PartialOption,
+    status: StatusEnum,
+    output: options.OutputEnum | None,
+) -> None:
+    """Reset as script to an earlier status
+
+    This will removed log files and
+    the script file, as needed.
+    """
+    result = client.reset_script(
+        fullname=fullname,
+        status=status,
+    )
+    _output_pydantic_object(result, output, db.Script.col_names_for_table)
+
+
+@action.command()
+@options.cmclient()
+@options.fullname()
 @options.script_name()
 @options.output()
 def retry_script(

--- a/src/lsst/cmservice/client.py
+++ b/src/lsst/cmservice/client.py
@@ -294,6 +294,8 @@ class CMClient:
 
     process = get_general_post_function(models.NodeQuery, tuple[bool, StatusEnum], "actions/process")
 
+    reset_script = get_general_post_function(models.UpdateStatusQuery, models.Script, "actions/reset_script")
+
     retry_script = get_general_post_function(models.ScriptQueryBase, models.Script, "actions/retry_script")
 
     rescue_script = get_general_post_function(models.ScriptQueryBase, models.Script, "actions/rescue_script")

--- a/src/lsst/cmservice/db/handler.py
+++ b/src/lsst/cmservice/db/handler.py
@@ -134,3 +134,55 @@ class Handler:
             Status of the processing
         """
         raise NotImplementedError(f"{type(self)}.run_check")
+
+    async def reset(
+        self,
+        session: async_scoped_session,
+        node: NodeMixin,
+        to_status: StatusEnum,
+    ) -> StatusEnum:
+        """reset a `Node` to an earlier status
+
+        Parameters
+        ----------
+        session : async_scoped_session
+            DB session manager
+
+        node: NodeMixin
+            The `Node` in question
+
+        to_status: StatusEnum
+            Status to reset the node to
+
+        Returns
+        -------
+        status : StatusEnum
+            Status of the processing
+        """
+        raise NotImplementedError(f"{type(self)}.process")
+
+    async def reset_script(
+        self,
+        session: async_scoped_session,
+        node: NodeMixin,
+        to_status: StatusEnum,
+    ) -> StatusEnum:
+        """reset a `Node` to an earlier status
+
+        Parameters
+        ----------
+        session : async_scoped_session
+            DB session manager
+
+        node: NodeMixin
+            The `Node` in question
+
+        to_status: StatusEnum
+            Status to reset the node to
+
+        Returns
+        -------
+        status : StatusEnum
+            Status of the processing
+        """
+        raise NotImplementedError(f"{type(self)}.process")

--- a/src/lsst/cmservice/db/script.py
+++ b/src/lsst/cmservice/db/script.py
@@ -100,6 +100,7 @@ class Script(Base, NodeMixin):
         "handler",
         "method",
         "stamp_url",
+        "script_url",
         "status",
         "superseded",
     ]
@@ -266,3 +267,31 @@ class Script(Base, NodeMixin):
             session.add(new_script)
         await session.refresh(new_script)
         return new_script
+
+    async def reset_script(
+        self,
+        session: async_scoped_session,
+        to_status: StatusEnum,
+    ) -> StatusEnum:
+        """Reset a script to a lower status
+        This will remove log files and processing
+        files.
+
+        This can not be used on script that have
+        completed processing.
+
+        Parameters
+        ----------
+        session : async_scoped_session
+            DB session manager
+
+        to_status : StatusEnum
+            Status to set script to
+
+        Returns
+        -------
+        status : StatusEnum
+            New status
+        """
+        handler = await self.get_handler(session)
+        return await handler.reset_script(session, self, to_status)

--- a/src/lsst/cmservice/handlers/functions.py
+++ b/src/lsst/cmservice/handlers/functions.py
@@ -140,8 +140,9 @@ async def create_specification(
             try:
                 spec_block_config_ = spec_block_list_item_["SpecBlockAssociation"]
             except KeyError as msg:
-                raise KeyError(f"Expected SpecBlockAssociation not {list(script_list_item_.keys())}") from msg
-
+                raise KeyError(
+                    f"Expected SpecBlockAssociation not {list(spec_block_list_item_.keys())}",
+                ) from msg
             new_spec_block_assoc = await SpecBlockAssociation.create_row(
                 session,
                 spec_name=spec_name,

--- a/src/lsst/cmservice/handlers/interface.py
+++ b/src/lsst/cmservice/handlers/interface.py
@@ -881,6 +881,49 @@ async def process(
     raise ValueError(f"Tried to process an row from a table of type {node_type}")
 
 
+async def reset_script(
+    session: async_scoped_session,
+    fullname: str,
+    status: StatusEnum,
+) -> db.Script:
+    """Run a retry on a `Script`
+
+    Notes
+    -----
+    This can only be run on failed/rejected scripts
+
+    This will mark the current version of the
+    script as superseded and create a new version
+    of the Script
+
+    Parameters
+    ----------
+    session : async_scoped_session
+        DB session manager
+
+    fullname: str
+        Full unique name for the script
+
+    status: StatusEnum
+        Status to set script to
+
+    Returns
+    -------
+    script : Script
+        Script in question
+
+    Raises
+    ------
+    ValueError : Script was not in failed/rejected status
+
+    HTTPException : Code 404, Could not find Node
+    """
+    script = await db.Script.get_row_by_fullname(session, fullname)
+    _result = await script.reset_script(session, status)
+    await session.commit()
+    return script
+
+
 async def retry_script(
     session: async_scoped_session,
     fullname: str,

--- a/src/lsst/cmservice/handlers/jobs.py
+++ b/src/lsst/cmservice/handlers/jobs.py
@@ -180,6 +180,34 @@ class BpsScriptHandler(ScriptHandler):
             await session.commit()
         return status
 
+    async def _reset_script(
+        self,
+        session: async_scoped_session,
+        script: Script,
+        to_status: StatusEnum,
+    ) -> dict[str, Any]:
+        update_fields = await ScriptHandler._reset_script(self, session, script, to_status)
+        if script.script_url and to_status.value <= StatusEnum.ready.value:
+            json_url = script.script_url.replace(".sh", "_log.json")
+            config_url = script.script_url.replace(".sh", "_bps_config.yaml")
+            submit_path = script.script_url.replace(
+                os.path.basename(script.script_url),
+                "/submit",
+            )
+            try:
+                os.unlink(json_url)
+            except Exception:
+                pass
+            try:
+                os.unlink(config_url)
+            except Exception:
+                pass
+            try:
+                os.rmdir(submit_path)
+            except Exception:
+                pass
+        return update_fields
+
 
 class BpsReportHandler(FunctionHandler):
     """Class to handle running BpsReport"""

--- a/src/lsst/cmservice/routers/actions.py
+++ b/src/lsst/cmservice/routers/actions.py
@@ -77,6 +77,20 @@ async def process(
 
 
 @router.post(
+    "/reset_script",
+    status_code=201,
+    response_model=models.Script,
+    summary="Reset `Script`",
+)
+async def reset_script(
+    query: models.UpdateStatusQuery,
+    session: async_scoped_session = Depends(db_session_dependency),
+) -> db.Script:
+    params = query.dict()
+    return await interface.reset_script(session, **params)
+
+
+@router.post(
     "/retry_script",
     status_code=201,
     response_model=models.Script,


### PR DESCRIPTION
Added tooling to be able to retry a script in place, like if you forget to do panda_auth.