### PR TITLE
DM-44523: Initial steps to run cm-service under k8s

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,3 +64,33 @@ jobs:
       - name: Run tests
         run: |
           make typing
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [test]
+    timeout-minutes: 10
+
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches. This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: lsst-sqre/build-and-push-to-ghcr@v1
+        id: build
+        with:
+          image: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report result
+        run: |
+          echo Pushed ghcr.io/${{ github.repository }}:${{ steps.build.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# Start a light linux distro with python 3.11
+FROM python:3.11.9-slim-bookworm as base-image
+# Install base packages
+COPY scripts/install-base-packages.sh .
+RUN ./install-base-packages.sh && rm ./install-base-packages.sh
+
+FROM base-image AS install-image
+
+# Install system packages only needed for building dependencies.
+COPY scripts/install-dependency-packages.sh .
+RUN ./install-dependency-packages.sh
+
+# Create a Python virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV
+
+# Make sure we use the virtualenv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Put the latest pip and setuptools in the virtualenv
+RUN pip install --upgrade --no-cache-dir pip setuptools wheel
+
+# Install the app's Python runtime dependencies
+COPY requirements/main.txt ./requirements.txt
+RUN pip install --quiet --no-cache-dir -r requirements.txt
+
+# Install the application.
+COPY . /workdir
+WORKDIR /workdir
+RUN pip install --no-cache-dir .
+
+FROM base-image AS runtime-image
+
+# Create the lsstsvc1 user
+RUN groupadd --gid 1126 gu
+RUN groupadd --gid 4085 rubin-users
+RUN groupadd --gid 2218 lsst
+RUN groupadd --gid 3967 lsstsvc1
+RUN useradd --create-home lsstsvc1 --uid 17951 --no-user-group --gid gu --groups rubin-users,lsst,lsstsvc1
+
+# Make sure we don't write output into the layer store
+VOLUME /output
+
+# Copy the virtualenv
+COPY --from=install-image /opt/venv /opt/venv
+
+# Copy the startup script
+COPY scripts/start-frontend.sh /start-frontend.sh
+
+# Copy over configs and point there with env var
+COPY examples /examples
+ENV CM_CONFIGS=/examples
+
+# Make sure we use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Switch to the lsstsvc1 user.
+USER lsstsvc1
+
+# Expose the port.
+EXPOSE 8080
+
+# Run the application.
+CMD ["/start-frontend.sh"]

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script updates packages in the base Docker image that's used by both the
+# build and runtime images, and gives us a place to install additional
+# system-level packages with apt-get.
+#
+# Based on the blog post:
+# https://pythonspeed.com/articles/system-packages-docker/
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Display each command as it's run.
+set -x
+
+# Tell apt-get we're never going to be able to give manual feedback.
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the package listing, so we know what packages exist.
+apt-get update
+
+# Install security updates.
+apt-get -y upgrade
+
+# Install dependencies required at runtime. libpq-dev is required by psycopg2.
+apt-get -y install --no-install-recommends libpq-dev
+
+# Delete cached files we don't need anymore.
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script installs additional packages used by the dependency image but
+# not needed by the runtime image, such as additional packages required to
+# build Python dependencies.
+#
+# Since the base image wipes all the apt caches to clean up the image that
+# will be reused by the runtime image, we unfortunately have to do another
+# apt-get update here, which wastes some time and network.
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Display each command as it's run.
+set -x
+
+# Tell apt-get we're never going to be able to give manual feedback.
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the package listing, so we know what packages exist.
+apt-get update
+
+# Install various dependencies that may be required to install vo-cutouts:
+#
+# build-essential: sometimes needed to build Python modules
+# git: required by setuptools_scm
+# libffi-dev: sometimes needed to build cffi, a cryptography dependency
+apt-get -y install --no-install-recommends build-essential git libffi-dev
+
+# Delete cached files we don't need anymore:
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/scripts/start-frontend.sh
+++ b/scripts/start-frontend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+cm-service init
+uvicorn lsst.cmservice.main:app --host 0.0.0.0 --port 8080


### PR DESCRIPTION
Part of k8s-ification of `cm-service`. This part:

* Adds `Dockerfile` and support scripts to build containerized `cm-service`.  The container contains the examples at `/examples` (and `CM_CONFIG` env var set to point there), has a volume mount for service output at `/output`, and runs as user `lsstsvc1`.

* Extends CI GHA to build and push docker container to github container registry.