### PR TITLE
DM-43591: Improve CM service unit tests for databases

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
 # Run Redis and PostgreSQL for testing with a local development server.
 # This is used by make run, which starts cm-service in the foreground.
 
-version: "3"
 name: "${USER}-cm-service"
 services:
   redis:

--- a/examples/empty_config.yaml
+++ b/examples/empty_config.yaml
@@ -36,3 +36,9 @@
       name: base
       spec_aliases:
           campaign: campaign
+      data:
+          var: dummy
+      collections:
+          coll: dummy
+      child_config:
+          child: dummy

--- a/tests/db/test_job.py
+++ b/tests/db/test_job.py
@@ -1,23 +1,23 @@
 import os
+import uuid
 
 import pytest
 import structlog
-import uuid
 from safir.database import create_async_session
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.exc import IntegrityError
 
 from lsst.cmservice import db
-import lsst.cmservice.common.errors as errors
 from lsst.cmservice.common.enums import LevelEnum
 from lsst.cmservice.config import config
+import lsst.cmservice.common.errors as errors
 
 from util_functions import create_tree, delete_all_productions
 
 
 @pytest.mark.asyncio()
-async def test_campaign_db(engine: AsyncEngine) -> None:
-    """Test `campaign` db table."""
+async def test_step_job(engine: AsyncEngine) -> None:
+    """Test `step` db table."""
 
     # generate a uuid to avoid collisions
     uuid_int = uuid.uuid1().int
@@ -27,65 +27,74 @@ async def test_campaign_db(engine: AsyncEngine) -> None:
         os.environ["CM_CONFIGS"] = "examples"
 
         # intialize a tree down to one level lower
-        await create_tree(session, LevelEnum.step, uuid_int)
+        await create_tree(session, LevelEnum.job, uuid_int)
 
         with pytest.raises(IntegrityError):
-            await db.Campaign.create_row(
+            await db.Job.create_row(
                 session,
-                name=f"camp0_{uuid_int}",
-                spec_block_assoc_name="base#campaign",
-                parent_name=f"prod0_{uuid_int}",
+                name=f"job_{uuid_int}",
+                spec_block_name="job",
+                parent_name=f"prod0_{uuid_int}/camp0_{uuid_int}/step0_{uuid_int}/group0_{uuid_int}",
             )
 
         # run row mixin method tests
-        check_getall = await db.Campaign.get_rows(
+        check_getall = await db.Job.get_rows(
             session,
-            parent_name=f"prod0_{uuid_int}",
-            parent_class=db.Production,
+            parent_name=f"prod0_{uuid_int}/camp0_{uuid_int}/step0_{uuid_int}/group0_{uuid_int}",
+            parent_class=db.Group,
         )
-        assert len(check_getall) == 1, "length should be 1"
+        assert len(check_getall) == 1, "length should be 2"
+
+        with pytest.raises(errors.CMMissingRowCreateInputError):
+            await db.Job.create_row(
+                session,
+                name="foo",
+                parent_name=f"prod0_{uuid_int}/camp0_{uuid_int}/step0_{uuid_int}/group0_{uuid_int}",
+            )
 
         entry = check_getall[0]  # defining single unit for later
 
-        check_getall_nonefound = await db.Campaign.get_rows(
+        check_getall_nonefound = await db.Job.get_rows(
             session,
-            parent_name="prod0_bad",
-            parent_class=db.Production,
+            parent_name="foo",
+            parent_class=db.Campaign,
         )
         assert len(check_getall_nonefound) == 0, "length should be 0"
 
-        check_get = await db.Campaign.get_row(session, entry.id)
+        check_get = await db.Job.get_row(session, entry.id)
         assert check_get.id == entry.id, "pulled row should be identical"
 
         with pytest.raises(errors.CMMissingIDError):
-            await db.Campaign.get_row(
+            await db.Job.get_row(
                 session,
                 -99,
             )
-
-        check_get_by_name = await db.Campaign.get_row_by_name(session, name=f"camp0_{uuid_int}")
+        check_get_by_name = await db.Job.get_row_by_name(session, name=f"job_{uuid_int}")
         assert check_get_by_name.id == entry.id, "pulled row should be identical"
 
         with pytest.raises(errors.CMMissingFullnameError):
-            await db.Campaign.get_row_by_name(session, name="foo")
+            await db.Job.get_row_by_name(session, name="foo")
 
-        check_get_by_fullname = await db.Campaign.get_row_by_fullname(session, entry.fullname)
+        check_get_by_fullname = await db.Job.get_row_by_fullname(session, entry.fullname)
         assert check_get_by_fullname.id == entry.id, "pulled row should be identical"
 
         with pytest.raises(errors.CMMissingFullnameError):
-            await db.Campaign.get_row_by_fullname(session, "foo")
+            await db.Job.get_row_by_fullname(session, "foo")
 
-        check_update = await db.Campaign.update_row(session, entry.id, data=dict(foo="bar"))
+        check_update = await db.Job.update_row(session, entry.id, data=dict(foo="bar"))
         assert check_update.data["foo"] == "bar", "foo value should be bar"
 
         check_update2 = await check_update.update_values(session, data=dict(bar="foo"))
         assert check_update2.data["bar"] == "foo", "bar value should be foo"
 
-        await db.Campaign.delete_row(session, -99)
+        await db.Step.delete_row(session, -99)
 
         # run campaign specific method tests
-        check = await entry.children(session)
-        assert len([c for c in check]) == 2, "length of children should be 2"
+        check = await entry.get_campaign(session)
+        assert check.name == f"camp0_{uuid_int}", "should return same name as camp0"
+
+        check = await entry.get_siblings(session)
+        assert len([c for c in check]) == 0, "length of siblings should be 0"
 
         check = await entry.get_tasks(session)
         assert len(check.reports) == 0, "length of tasks should be 0"
@@ -95,6 +104,8 @@ async def test_campaign_db(engine: AsyncEngine) -> None:
 
         check = await entry.get_products(session)
         assert len(check.reports) == 0, "length of products should be 0"
+
+        assert entry.db_id.level == LevelEnum.job, "enum should match job"
 
         # delete everything we just made in the session
         await delete_all_productions(session)

--- a/tests/db/test_production.py
+++ b/tests/db/test_production.py
@@ -1,52 +1,93 @@
 import os
-from uuid import uuid1
 
 import pytest
 import structlog
+import uuid
 from safir.database import create_async_session
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from lsst.cmservice import db
 from lsst.cmservice.common.enums import LevelEnum
+import lsst.cmservice.common.errors as errors
+
 from lsst.cmservice.config import config
-from lsst.cmservice.handlers import interface
+
+from util_functions import create_tree, delete_all_productions
 
 
 @pytest.mark.asyncio()
 async def test_production_db(engine: AsyncEngine) -> None:
     """Test `production` db table."""
 
+    # generate a uuid to avoid collisions
+    uuid_int = uuid.uuid1().int
     logger = structlog.get_logger(config.logger_name)
     async with engine.begin():
         session = await create_async_session(engine, logger)
         os.environ["CM_CONFIGS"] = "examples"
-        specification = await interface.load_specification(session, "examples/empty_config.yaml")
-        check2 = await specification.get_block(session, "campaign")
-        assert check2.name == "campaign"
 
-        # Check production name UNIQUE constraint
-        pname = str(uuid1())
+        # intialize a tree down to one level lower
+        await create_tree(session, LevelEnum.campaign, uuid_int)
 
-        p1 = await db.Production.create_row(session, name=pname)
         with pytest.raises(IntegrityError):
-            p1 = await db.Production.create_row(session, name=pname)
+            await db.Production.create_row(
+                session,
+                name=f"prod0_{uuid_int}",
+            )
 
-        check = await db.Production.get_row(session, p1.id)
-        assert check.name == p1.name
-        assert check.fullname == p1.fullname
+        # run row mixin method tests
+        check_getall = await db.Production.get_rows(
+            session,
+        )
+        assert len(check_getall) == 1, "length should be 1"
 
-        assert check.db_id.level == LevelEnum.production
-        assert check.db_id.id == p1.id
+        entry = check_getall[0]  # defining single unit for later
 
-        prods = await db.Production.get_rows(session)
-        n_prod = len(prods)
-        assert n_prod >= 1
+        check_get = await db.Production.get_row(session, entry.id)
+        assert check_get.id == entry.id, "pulled row should be identical"
 
-        await db.Production.delete_row(session, p1.id)
+        with pytest.raises(errors.CMMissingIDError):
+            await db.Production.get_row(
+                session,
+                -99,
+            )
 
-        prods = await db.Production.get_rows(session)
-        assert len(prods) == n_prod - 1
+        check_get_by_name = await db.Production.get_row_by_name(session, name=f"prod0_{uuid_int}")
+        assert check_get_by_name.id == entry.id, "pulled row should be identical"
 
-        # Finish clean up
+        with pytest.raises(errors.CMMissingFullnameError):
+            await db.Production.get_row_by_name(session, name="foo")
+
+        check_get_by_fullname = await db.Production.get_row_by_fullname(session, entry.fullname)
+        assert check_get_by_fullname.id == entry.id, "pulled row should be identical"
+
+        with pytest.raises(errors.CMMissingFullnameError):
+            await db.Production.get_row_by_fullname(session, "foo")
+
+        check_update = await db.Production.update_row(session, entry.id, name="foo")
+        assert check_update.name == "foo", "name should be foo"
+
+        check_update2 = await check_update.update_values(session, name="bar")
+        assert check_update2.name == "bar", "name should be bar"
+
+        assert entry.db_id.level == LevelEnum.production, "enum should match production"
+        assert entry.level == LevelEnum.production, "level should match production"
+
+        # TODO: decide how to handle this case
+        # when trying to delete a row that does not exist.
+        await db.Production.delete_row(session, -99)
+
+        # run campaign specific method tests
+        check = await entry.children(session)
+        assert len([c for c in check]) == 1, "length of children should be 2"
+
+        # delete everything we just made in the session
+        await delete_all_productions(session)
+
+        # confirm cleanup
+        productions = await db.Production.get_rows(
+            session,
+        )
+        assert len(productions) == 0
         await session.remove()

--- a/tests/db/test_step.py
+++ b/tests/db/test_step.py
@@ -1,87 +1,128 @@
 import os
-from uuid import uuid1
 
 import pytest
 import structlog
+import uuid
 from safir.database import create_async_session
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from lsst.cmservice import db
+from lsst.cmservice.common.enums import LevelEnum
+import lsst.cmservice.common.errors as errors
 from lsst.cmservice.config import config
-from lsst.cmservice.handlers import interface
+
+from util_functions import create_tree, delete_all_productions
 
 
 @pytest.mark.asyncio()
 async def test_step_db(engine: AsyncEngine) -> None:
-    """Test the Step db table interface"""
+    """Test `step` db table."""
 
+    # generate a uuid to avoid collisions
+    uuid_int = uuid.uuid1().int
     logger = structlog.get_logger(config.logger_name)
     async with engine.begin():
         session = await create_async_session(engine, logger)
         os.environ["CM_CONFIGS"] = "examples"
-        specification = await interface.load_specification(session, "examples/empty_config.yaml")
-        check2 = await specification.get_block(session, "campaign")
-        assert check2.name == "campaign"
 
-        pname = str(uuid1())
-        prod = await db.Production.create_row(session, name=pname)
-        cnames = [str(uuid1()) for n in range(2)]
-        camps = [
-            await db.Campaign.create_row(
-                session,
-                name=cname_,
-                spec_block_assoc_name="base#campaign",
-                parent_name=pname,
-            )
-            for cname_ in cnames
-        ]
-        assert len(camps) == 2
-
-        snames = [str(uuid1()) for n in range(5)]
-
-        steps0 = [
-            await db.Step.create_row(
-                session,
-                name=sname_,
-                spec_block_name="basic_step",
-                parent_name=camps[0].fullname,
-            )
-            for sname_ in snames
-        ]
-        assert len(steps0) == 5
-
-        steps1 = [
-            await db.Step.create_row(
-                session,
-                name=sname_,
-                spec_block_name="basic_step",
-                parent_name=camps[1].fullname,
-            )
-            for sname_ in snames
-        ]
-        assert len(steps1) == 5
+        # intialize a tree down to one level lower
+        await create_tree(session, LevelEnum.group, uuid_int)
 
         with pytest.raises(IntegrityError):
             await db.Step.create_row(
                 session,
-                name=snames[0],
-                parent_name=camps[0].fullname,
+                name=f"step0_{uuid_int}",
                 spec_block_name="basic_step",
+                parent_name=f"prod0_{uuid_int}/camp0_{uuid_int}",
             )
 
-        await db.Campaign.delete_row(session, camps[0].id)
-        check_gone = await db.Step.get_rows(session, parent_id=camps[0].id, parent_class=db.Campaign)
-        assert len(check_gone) == 0
+        # run row mixin method tests
+        check_getall = await db.Step.get_rows(
+            session,
+            parent_name=f"prod0_{uuid_int}/camp0_{uuid_int}",
+            parent_class=db.Campaign,
+        )
+        assert len(check_getall) == 2, "length should be 2"
 
-        check_here = await db.Step.get_rows(session, parent_id=camps[1].id, parent_class=db.Campaign)
-        assert len(check_here) == 5
+        # set prereqs on steps for testing
+        await db.StepDependency.create_row(
+            session,
+            prereq_id=check_getall[1].id,
+            depend_id=check_getall[0].id,
+        )
 
-        await db.Step.delete_row(session, steps1[0].id)
+        with pytest.raises(errors.CMMissingRowCreateInputError):
+            await db.Step.create_row(
+                session,
+                name="foo",
+                parent_name=f"camp0{uuid_int}",
+            )
 
-        check_here = await db.Step.get_rows(session, parent_id=camps[1].id, parent_class=db.Campaign)
-        assert len(check_here) == 4
+        entry = check_getall[0]  # defining single unit for later
 
-        # Finish clean up
-        await db.Production.delete_row(session, prod.id)
+        check_getall_nonefound = await db.Step.get_rows(
+            session,
+            parent_name="foo",
+            parent_class=db.Campaign,
+        )
+        assert len(check_getall_nonefound) == 0, "length should be 0"
+
+        check_get = await db.Step.get_row(session, entry.id)
+        assert check_get.id == entry.id, "pulled row should be identical"
+
+        with pytest.raises(errors.CMMissingIDError):
+            await db.Step.get_row(
+                session,
+                -99,
+            )
+        check_get_by_name = await db.Step.get_row_by_name(session, name=f"step0_{uuid_int}")
+        assert check_get_by_name.id == entry.id, "pulled row should be identical"
+
+        with pytest.raises(errors.CMMissingFullnameError):
+            await db.Step.get_row_by_name(session, name="foo")
+
+        check_get_by_fullname = await db.Step.get_row_by_fullname(session, entry.fullname)
+        assert check_get_by_fullname.id == entry.id, "pulled row should be identical"
+
+        with pytest.raises(errors.CMMissingFullnameError):
+            await db.Step.get_row_by_fullname(session, "foo")
+
+        check_update = await db.Step.update_row(session, entry.id, data=dict(foo="bar"))
+        assert check_update.data["foo"] == "bar", "foo value should be bar"
+
+        check_update2 = await check_update.update_values(session, data=dict(bar="foo"))
+        assert check_update2.data["bar"] == "foo", "bar value should be foo"
+
+        await db.Campaign.delete_row(session, -99)
+
+        # run campaign specific method tests
+        check = await entry.get_campaign(session)
+        assert check.name == f"camp0_{uuid_int}", "should return same name as camp0"
+
+        check = await entry.get_all_prereqs(session)
+        assert len(check) == 1, "should be one prereq"
+
+        check = await entry.children(session)
+        assert len([c for c in check]) == 5, "length of children should be 5"
+
+        check = await entry.get_tasks(session)
+        assert len(check.reports) == 0, "length of tasks should be 0"
+
+        check = await entry.get_wms_reports(session)
+        assert len(check.reports) == 0, "length of reports should be 0"
+
+        check = await entry.get_products(session)
+        assert len(check.reports) == 0, "length of products should be 0"
+
+        assert entry.db_id.level == LevelEnum.step, "enum should match step"
+
+        # delete everything we just made in the session
+        await delete_all_productions(session)
+
+        # confirm cleanup
+        productions = await db.Production.get_rows(
+            session,
+        )
+        assert len(productions) == 0
         await session.remove()

--- a/tests/db/util_functions.py
+++ b/tests/db/util_functions.py
@@ -1,0 +1,78 @@
+from sqlalchemy.ext.asyncio import async_scoped_session
+
+from lsst.cmservice import db
+from lsst.cmservice.handlers import interface
+from lsst.cmservice.common.enums import LevelEnum
+
+
+async def create_tree(
+    session: async_scoped_session,
+    level: LevelEnum,
+    uuid_int: int,
+) -> None:
+    specification = await interface.load_specification(session, "examples/empty_config.yaml")
+    _ = await specification.get_block(session, "campaign")
+
+    pname = f"prod0_{uuid_int}"
+    _ = await db.Production.create_row(session, name=pname)
+
+    cname = f"camp0_{uuid_int}"
+    camp = await db.Campaign.create_row(
+        session,
+        name=cname,
+        spec_block_assoc_name="base#campaign",
+        parent_name=pname,
+    )
+
+    if level.value <= LevelEnum.campaign.value:
+        return
+
+    snames = [f"step{i}_{uuid_int}" for i in range(2)]
+    steps = [
+        await db.Step.create_row(
+            session,
+            name=sname_,
+            spec_block_name="basic_step",
+            parent_name=camp.fullname,
+        )
+        for sname_ in snames
+    ]
+
+    if level.value <= LevelEnum.step.value:
+        return
+
+    gnames = [f"group{i}_{uuid_int}" for i in range(5)]
+    groups = [
+        await db.Group.create_row(
+            session,
+            name=gname_,
+            spec_block_name="group",
+            parent_name=steps[0].fullname,
+        )
+        for gname_ in gnames
+    ]
+
+    if level.value <= LevelEnum.group.value:
+        return
+
+    _ = [
+        await db.Job.create_row(
+            session,
+            name=f"job_{uuid_int}",
+            spec_block_name="job",
+            parent_name=group_.fullname,
+        )
+        for group_ in groups
+    ]
+    return
+
+
+async def delete_all_productions(
+    session: async_scoped_session,
+) -> None:
+    productions = await db.Production.get_rows(
+        session,
+    )
+
+    for prod_ in productions:
+        await db.Production.delete_row(session, prod_.id)


### PR DESCRIPTION
This push unifies much of the database unit testing and expands the coverage.