### PR TITLE
DM-45838 fix broken script links in campaign cards

### DIFF
--- a/src/lsst/cmservice/web_app/app.py
+++ b/src/lsst/cmservice/web_app/app.py
@@ -250,16 +250,20 @@ async def get_script(
     session: async_scoped_session = Depends(db_session_dependency),
 ) -> HTMLResponse:
     try:
-        script_details = await get_script_by_id(session, script_id)
+        script_details = await get_script_by_id(
+            session,
+            script_id=script_id,
+            campaign_id=campaign_id,
+            step_id=step_id,
+            group_id=group_id,
+            job_id=job_id,
+        )
+        print(script_details)
         return templates.TemplateResponse(
             name="script_details.html",
             request=request,
             context={
                 "script": script_details,
-                "campaign_id": campaign_id,
-                "step_id": step_id,
-                "group_id": group_id,
-                "job_id": job_id,
             },
         )
     except Exception as e:

--- a/src/lsst/cmservice/web_app/app.py
+++ b/src/lsst/cmservice/web_app/app.py
@@ -185,8 +185,6 @@ async def get_step(
 async def get_group(
     request: Request,
     group_id: int,
-    campaign_id: int | None = None,
-    step_id: int | None = None,
     session: async_scoped_session = Depends(db_session_dependency),
 ) -> HTMLResponse:
     try:
@@ -195,8 +193,6 @@ async def get_group(
             name="group_details.html",
             request=request,
             context={
-                # "campaign_id": campaign_id,
-                # "step_id": step_id,
                 "group": group_details,
                 "jobs": jobs,
                 "scripts": scripts,
@@ -258,7 +254,6 @@ async def get_script(
             group_id=group_id,
             job_id=job_id,
         )
-        print(script_details)
         return templates.TemplateResponse(
             name="script_details.html",
             request=request,

--- a/src/lsst/cmservice/web_app/pages/script_details.py
+++ b/src/lsst/cmservice/web_app/pages/script_details.py
@@ -75,7 +75,7 @@ async def get_script_by_id(
         return script_details
 
 
-async def get_step_id_by_fullname(session, fullname):
+async def get_step_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
     print(f"step_fullname: {fullname}")
     q = select(Step.id).where(Step.fullname == fullname)
     async with session.begin_nested():
@@ -83,19 +83,17 @@ async def get_step_id_by_fullname(session, fullname):
         return results.one_or_none()
 
 
-async def get_group_id_by_fullname(session, fullname):
+async def get_group_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
     print(f"group_fullname: {fullname}")
     q = select(Group.id).where(Group.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
-        id = results.one()
-        return id
+        return results.one_or_none()
 
 
-async def get_job_id_by_fullname(session, fullname):
+async def get_job_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
     print(f"job_fullname: {fullname}")
     q = select(Job.id).where(Job.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
-        id = results.one()
-        return id
+        return results.one_or_none()

--- a/src/lsst/cmservice/web_app/pages/script_details.py
+++ b/src/lsst/cmservice/web_app/pages/script_details.py
@@ -76,7 +76,6 @@ async def get_script_by_id(
 
 
 async def get_step_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
-    print(f"step_fullname: {fullname}")
     q = select(Step.id).where(Step.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
@@ -84,7 +83,6 @@ async def get_step_id_by_fullname(session: async_scoped_session, fullname: str) 
 
 
 async def get_group_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
-    print(f"group_fullname: {fullname}")
     q = select(Group.id).where(Group.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
@@ -92,7 +90,6 @@ async def get_group_id_by_fullname(session: async_scoped_session, fullname: str)
 
 
 async def get_job_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
-    print(f"job_fullname: {fullname}")
     q = select(Job.id).where(Job.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)

--- a/src/lsst/cmservice/web_app/pages/script_details.py
+++ b/src/lsst/cmservice/web_app/pages/script_details.py
@@ -2,8 +2,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_scoped_session
 
-from lsst.cmservice.db import Script
-from lsst.cmservice.common.enums import LevelEnum
+from lsst.cmservice.db import Script, Job, Group, Step
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
@@ -32,23 +31,25 @@ async def get_script_by_id(
         results = await session.scalars(q)
         script = results.one()
         script_details = None
-        c_id = None
         s_id = None
         g_id = None
         j_id = None
 
         if script is not None:
-            if campaign_id is None:
-                campaign = await script.get_campaign(session)
-                c_id = campaign.id
-            parent = await script.get_parent(session)
-            if not parent.level == LevelEnum.campaign:
-                if parent.level == LevelEnum.step:
-                    s_id = script.parent_id if step_id is None else step_id
-                elif parent.level == LevelEnum.group:
-                    g_id = script.parent_id if step_id is None else group_id
-                elif parent.level == LevelEnum.job:
-                    j_id = script.parent_id if step_id is None else job_id
+            fullname = script.fullname.split("/")
+            for i in range(2, len(fullname) - 1):
+                match i:
+                    case 2:
+                        if step_id is None:
+                            s_id = await get_step_id_by_fullname(session, "/".join(fullname[:3]))
+                    case 3:
+                        if group_id is None:
+                            g_id = await get_group_id_by_fullname(session, "/".join(fullname[:4]))
+                    case 4:
+                        print("getting job id")
+                        if job_id is None:
+                            j_id = await get_job_id_by_fullname(session, "/".join(fullname[:5]))
+
             collections = await script.resolve_collections(session)
             filtered_collections = dict(
                 filter(
@@ -59,7 +60,7 @@ async def get_script_by_id(
             script_details = {
                 "id": script.id,
                 "name": script.name,
-                "campaign_id": c_id,
+                "campaign_id": campaign_id,
                 "step_id": s_id,
                 "group_id": g_id,
                 "job_id": j_id,
@@ -72,3 +73,29 @@ async def get_script_by_id(
             }
 
         return script_details
+
+
+async def get_step_id_by_fullname(session, fullname):
+    print(f"step_fullname: {fullname}")
+    q = select(Step.id).where(Step.fullname == fullname)
+    async with session.begin_nested():
+        results = await session.scalars(q)
+        return results.one_or_none()
+
+
+async def get_group_id_by_fullname(session, fullname):
+    print(f"group_fullname: {fullname}")
+    q = select(Group.id).where(Group.fullname == fullname)
+    async with session.begin_nested():
+        results = await session.scalars(q)
+        id = results.one()
+        return id
+
+
+async def get_job_id_by_fullname(session, fullname):
+    print(f"job_fullname: {fullname}")
+    q = select(Job.id).where(Job.fullname == fullname)
+    async with session.begin_nested():
+        results = await session.scalars(q)
+        id = results.one()
+        return id

--- a/src/lsst/cmservice/web_app/templates/script_details.html
+++ b/src/lsst/cmservice/web_app/templates/script_details.html
@@ -10,13 +10,13 @@
           {% if i == 0 %}
           {% set parent_link = url_for('get_campaigns') %}
           {% elif i == 1 %}
-          {% set parent_link = url_for('get_steps', campaign_id=campaign_id) %}
+          {% set parent_link = url_for('get_steps', campaign_id=script.campaign_id) %}
           {% elif i == 2 %}
-          {% set parent_link = url_for('get_step', campaign_id=campaign_id, step_id=step_id) %}
+          {% set parent_link = url_for('get_step', campaign_id=script.campaign_id, step_id=script.step_id) %}
           {% elif i == 3 %}
-          {% set parent_link = url_for('get_group', campaign_id=campaign_id, step_id=step_id, group_id=group_id) %}
+          {% set parent_link = url_for('get_group', campaign_id=script.campaign_id, step_id=script.step_id, group_id=script.group_id) %}
           {% else %}
-          {% set parent_link = url_for('get_job', campaign_id=campaign_id, step_id=step_id, group_id=group_id, job_id=job_id) %}
+          {% set parent_link = url_for('get_job', campaign_id=script.campaign_id, step_id=script.step_id, group_id=script.group_id, job_id=script.job_id) %}
           {% endif %}
           <a href="{{ parent_link }}" class="ml-2 mr-2 text-sm font-medium text-gray-500 hover:text-gray-700">{{ fullname[i] }}</a>
 


### PR DESCRIPTION
If script details page is opened directly through campaign card in home page (a link to a script the needs attention), breadcrumbs are sometimes broken because not all parent ID’s down the tree are available.

This change retrieves all ID’s if not provided in the path