### PR TITLE
DM-46999: Add gafaelfawr token and configurable timeout support to `cm-client`

### DIFF
--- a/src/lsst/cmservice/client/client.py
+++ b/src/lsst/cmservice/client/client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 
 from .actions import CMActionClient
@@ -35,12 +37,13 @@ class CMClient:  # pylint: disable=too-many-instance-attributes
     """Interface for accessing remote cm-service."""
 
     def __init__(self: CMClient) -> None:
-        # Use url and bearer token (if any) from client settings object
-        base_url = client_config.service_url
-        headers = {}
-        if client_config.auth_token is not None:
-            headers["Authorization"] = f"Bearer {client_config.auth_token}"
-        self._client = httpx.Client(base_url=base_url, headers=headers)
+        client_kwargs: dict[str, Any] = {}
+        client_kwargs["base_url"] = client_config.service_url
+        if "auth_token" in client_config.model_fields_set:
+            client_kwargs["headers"] = {"Authorization": f"Bearer {client_config.auth_token}"}
+        if "timeout" in client_config.model_fields_set:
+            client_kwargs["timeout"] = client_config.timeout
+        self._client = httpx.Client(**client_kwargs)
 
         self.production = CMProductionClient(self)
         self.campaign = CMCampaignClient(self)

--- a/src/lsst/cmservice/client/client.py
+++ b/src/lsst/cmservice/client/client.py
@@ -7,6 +7,7 @@ import httpx
 from .actions import CMActionClient
 from .adders import CMAddClient
 from .campaigns import CMCampaignClient
+from .clientconfig import client_config
 from .groups import CMGroupClient
 from .jobs import CMJobClient
 from .loaders import CMLoadClient
@@ -33,8 +34,14 @@ __all__ = ["CMClient"]
 class CMClient:  # pylint: disable=too-many-instance-attributes
     """Interface for accessing remote cm-service."""
 
-    def __init__(self: CMClient, url: str) -> None:
-        self._client = httpx.Client(base_url=url)
+    def __init__(self: CMClient) -> None:
+        # Use url and bearer token (if any) from client settings object
+        base_url = client_config.service_url
+        headers = {}
+        if client_config.auth_token is not None:
+            headers["Authorization"] = f"Bearer {client_config.auth_token}"
+        self._client = httpx.Client(base_url=base_url, headers=headers)
+
         self.production = CMProductionClient(self)
         self.campaign = CMCampaignClient(self)
         self.step = CMStepClient(self)

--- a/src/lsst/cmservice/client/clientconfig.py
+++ b/src/lsst/cmservice/client/clientconfig.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+__all__ = ["ClientConfiguration", "client_config"]
+
+
+class ClientConfiguration(BaseSettings):
+    """Configuration for cm-client."""
+
+    model_config = SettingsConfigDict(env_file="~/.cm-client", env_file_encoding="utf-8")
+
+    service_url: str = Field(
+        default="http://localhost:8080/cm-service/v1",
+        validation_alias="CM_SERVICE",
+    )
+
+    auth_token: str | None = Field(
+        default=None,
+        validation_alias="CM_TOKEN",
+    )
+
+
+client_config = ClientConfiguration()
+"""Configuration for cm-client."""

--- a/src/lsst/cmservice/client/clientconfig.py
+++ b/src/lsst/cmservice/client/clientconfig.py
@@ -1,4 +1,6 @@
-from pydantic import Field
+from typing import Any
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 __all__ = ["ClientConfiguration", "client_config"]
@@ -18,6 +20,19 @@ class ClientConfiguration(BaseSettings):
         default=None,
         validation_alias="CM_TOKEN",
     )
+
+    timeout: float | None = Field(
+        default=None,
+        validation_alias="CM_TIMEOUT",
+    )
+
+    # Field validator to convert empty string, 'null', or 'None' to actual None
+    @field_validator("timeout", mode="before", check_fields=True)
+    @classmethod
+    def validate_timeout(cls, v: Any) -> float | None:
+        if isinstance(v, str) and v in {"", "null", "None"}:
+            return None
+        return v
 
 
 client_config = ClientConfiguration()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2,13 +2,14 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice.cli.commands import client_top, server
+from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 
 
 def test_commands(uvicorn: UvicornProcess) -> None:
     """Test the cli"""
-    env = {"CM_SERVICE": f"{uvicorn.url}{config.prefix}"}
-    runner = CliRunner(env=env)
+    client_config.service_url = f"{uvicorn.url}{config.prefix}"
+    runner = CliRunner()
 
     result = runner.invoke(server, "--version")
     assert result.exit_code == 0


### PR DESCRIPTION
`cm-service` instances running under k8s at USDF are gafaelfawr-protected.  In order for the client to talk to these instances, the embedded `httpx` client must be configured to present a valid bearer token with each request.

This PR:

* Adds a client-specific Pydantic settings class, which holds the remote service URL and token.  The token may be `None` if unspecified.  These settings are initialized from env vars `CM_SERVICE` and `CM_TOKEN` (respectively) if set, or receive defaults `http://localhost:8080/cm-service/v1` and `None` (respectively) if not.

* Adds an `httpx` client timeout setting, which can be set via `CM_TIMEOUT` env var.  If unspecified, the `httpx` default timeout (5s) is used.  If specified, can be either a float number of seconds, or `None` or `null` to disable client timeout entirely (waits as long as it takes...)

* Adds support for a local "dotenv" format config file (`~/.cm-client`) where users may specify these settings persistently, as an alternative to mucking about with env vars.  This gives users a reasonably convenient place to persist tokens e.g. obtained from the service `/auth/tokens` endpoint.  If specified, env vars always override the corresponding settings in the dotenv file.

Note that the previously supported (but seldom used) `--server` CLI option is no longer supported, as a consequence of moving configuration of the service URL from `click` to `pydantic`.