### PR TITLE
DM-47897 : Refactor CLI to Support Standard Python Module Invocation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = []
 dynamic = ["version"]
 
 [project.scripts]
-cm-service = "lsst.cmservice.cli.commands:server"
-cm-client = "lsst.cmservice.cli.commands:client_top"
+cm-service = "lsst.cmservice.cli.server:server"
+cm-client = "lsst.cmservice.cli.client:client_top"
 cm-worker = "lsst.cmservice.daemon:main"
 
 [project.urls]

--- a/src/lsst/cmservice/cli/__init__.py
+++ b/src/lsst/cmservice/cli/__init__.py
@@ -15,30 +15,3 @@ action: specfic database actions
 load: reading yaml files an loading objects into the database
 query: getting objects from the database
 """
-
-
-from . import (
-    action,
-    campaign,
-    commands,
-    group,
-    job,
-    load,
-    options,
-    pipetask_error,
-    pipetask_error_type,
-    product_set,
-    production,
-    queue,
-    script,
-    script_dependency,
-    script_error,
-    script_template,
-    spec_block,
-    specificaiton,
-    step,
-    step_dependency,
-    task_set,
-    wms_task_report,
-    wrappers,
-)

--- a/src/lsst/cmservice/cli/action.py
+++ b/src/lsst/cmservice/cli/action.py
@@ -1,19 +1,20 @@
 from typing import Any
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from ..common.enums import StatusEnum
 from . import options
-from .commands import client_top
 from .wrappers import output_dict, output_pydantic_list, output_pydantic_object
 
 
-@client_top.group()
-def action() -> None:
+@click.group(name="action")
+def action_group() -> None:
     """Do something"""
 
 
-@action.command()
+@action_group.command()
 @options.cmclient()
 @options.fullname()
 @options.fake_status()
@@ -36,7 +37,7 @@ def process(
     output_dict({"changed": changed, "status": status}, output)
 
 
-@action.command()
+@action_group.command()
 @options.cmclient()
 @options.fullname()
 @options.status()
@@ -59,7 +60,7 @@ def reset_script(
     output_pydantic_object(result, output, db.Script.col_names_for_table)
 
 
-@action.command()
+@action_group.command()
 @options.cmclient()
 @options.fullname()
 @options.output()
@@ -78,7 +79,7 @@ def rescue_job(
     output_pydantic_object(result, output, db.Job.col_names_for_table)
 
 
-@action.command()
+@action_group.command()
 @options.cmclient()
 @options.fullname()
 @options.output()
@@ -98,7 +99,7 @@ def mark_job_rescued(
     output_pydantic_list(result, output, db.Job.col_names_for_table)
 
 
-@action.command()
+@action_group.command()
 @options.cmclient()
 @options.rematch()
 @options.output()

--- a/src/lsst/cmservice/cli/campaign.py
+++ b/src/lsst/cmservice/cli/campaign.py
@@ -1,11 +1,12 @@
 """CLI to manage Campaign table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="campaign")
+@click.group(name="campaign")
 def campaign_group() -> None:
     """Manage Campaign table"""
 

--- a/src/lsst/cmservice/cli/client.py
+++ b/src/lsst/cmservice/cli/client.py
@@ -1,0 +1,58 @@
+import click
+
+from .. import __version__
+from .action import action_group
+from .campaign import campaign_group
+from .group import group_group
+from .job import job_group
+from .load import load_group
+from .pipetask_error import pipetask_error_group
+from .pipetask_error_type import pipetask_error_type_group
+from .product_set import product_set_group
+from .production import production_group
+from .queue import queue_group
+from .script import script_group
+from .script_dependency import script_dependency_group
+from .script_error import script_error_group
+from .script_template import script_template_group
+from .spec_block import spec_block_group
+from .specification import specification_group
+from .step import step_group
+from .step_dependency import step_dependency_group
+from .task_set import task_set_group
+from .wms_task_report import wms_task_report_group
+
+
+# Build the client CLI
+@click.group(
+    name="client",
+    commands=[
+        action_group,
+        campaign_group,
+        group_group,
+        job_group,
+        load_group,
+        pipetask_error_group,
+        pipetask_error_type_group,
+        product_set_group,
+        production_group,
+        queue_group,
+        script_group,
+        script_dependency_group,
+        script_error_group,
+        script_template_group,
+        spec_block_group,
+        specification_group,
+        step_dependency_group,
+        step_group,
+        task_set_group,
+        wms_task_report_group,
+    ],
+)
+@click.version_option(version=__version__)
+def client_top() -> None:
+    """Administrative command-line interface client-side commands."""
+
+
+if __name__ == "__main__":
+    client_top()

--- a/src/lsst/cmservice/cli/group.py
+++ b/src/lsst/cmservice/cli/group.py
@@ -1,12 +1,13 @@
 """CLI to manage Group table"""
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="group")
+@click.group(name="group")
 def group_group() -> None:
     """Manage Group table"""
 

--- a/src/lsst/cmservice/cli/job.py
+++ b/src/lsst/cmservice/cli/job.py
@@ -1,12 +1,13 @@
 """CLI to manage Job table"""
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="job")
+@click.group(name="job")
 def job_group() -> None:
     """Manage Job table"""
 

--- a/src/lsst/cmservice/cli/load.py
+++ b/src/lsst/cmservice/cli/load.py
@@ -1,18 +1,19 @@
 from typing import Any
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from . import options
-from .commands import client_top
 from .wrappers import output_pydantic_list, output_pydantic_object
 
 
-@client_top.group()
-def load() -> None:
+@click.group(name="load")
+def load_group() -> None:
     """Read a yaml file and add stuff to the DB"""
 
 
-@load.command()
+@load_group.command()
 @options.cmclient()
 @options.output()
 @options.yaml_file()
@@ -41,7 +42,7 @@ def specification(
         output_pydantic_list(script_templates, output, db.ScriptTemplate.col_names_for_table)
 
 
-@load.command(name="campaign")
+@load_group.command(name="campaign")
 @options.cmclient()
 @options.output()
 @options.campaign_yaml()
@@ -66,7 +67,7 @@ def campaign(
     output_pydantic_object(result, output, db.Campaign.col_names_for_table)
 
 
-@load.command()
+@load_group.command()
 @options.cmclient()
 @options.output()
 @options.yaml_file()
@@ -81,7 +82,7 @@ def error_types(
     output_pydantic_list(result, output, db.PipetaskErrorType.col_names_for_table)
 
 
-@load.command()
+@load_group.command()
 @options.cmclient()
 @options.output()
 @options.fullname()

--- a/src/lsst/cmservice/cli/pipetask_error.py
+++ b/src/lsst/cmservice/cli/pipetask_error.py
@@ -1,11 +1,12 @@
 """CLI to manage PipetaskError table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="pipetask_error")
+@click.group(name="pipetask_error")
 def pipetask_error_group() -> None:
     """Manage PipetaskError table"""
 

--- a/src/lsst/cmservice/cli/pipetask_error_type.py
+++ b/src/lsst/cmservice/cli/pipetask_error_type.py
@@ -1,11 +1,12 @@
 """CLI to manage PipetaskErrorType table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="pipetask_error_type")
+@click.group(name="pipetask_error_type")
 def pipetask_error_type_group() -> None:
     """Manage PipetaskErrorType table"""
 

--- a/src/lsst/cmservice/cli/product_set.py
+++ b/src/lsst/cmservice/cli/product_set.py
@@ -1,11 +1,12 @@
 """CLI to manage ProductSet table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="product_set")
+@click.group(name="product_set")
 def product_set_group() -> None:
     """Manage ProductSet table"""
 

--- a/src/lsst/cmservice/cli/production.py
+++ b/src/lsst/cmservice/cli/production.py
@@ -1,11 +1,12 @@
 """CLI to manage Production table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="production")
+@click.group(name="production")
 def production_group() -> None:
     """Manage production table"""
 

--- a/src/lsst/cmservice/cli/queue.py
+++ b/src/lsst/cmservice/cli/queue.py
@@ -1,12 +1,13 @@
 """CLI to manage Queue table"""
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="queue")
+@click.group(name="queue")
 def queue_group() -> None:
     """Manage the processing queue"""
 

--- a/src/lsst/cmservice/cli/script.py
+++ b/src/lsst/cmservice/cli/script.py
@@ -1,12 +1,13 @@
 """CLI to manage Script table"""
 
+import click
+
 from .. import db
 from ..client.client import CMClient
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="script")
+@click.group(name="script")
 def script_group() -> None:
     """Manage Script table"""
 

--- a/src/lsst/cmservice/cli/script_dependency.py
+++ b/src/lsst/cmservice/cli/script_dependency.py
@@ -1,11 +1,12 @@
 """CLI to manage ScriptDependency table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="script_dependency")
+@click.group(name="script_dependency")
 def script_dependency_group() -> None:
     """Manage ScriptDependency table"""
 

--- a/src/lsst/cmservice/cli/script_error.py
+++ b/src/lsst/cmservice/cli/script_error.py
@@ -1,11 +1,12 @@
 """CLI to manage PipetaskError table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="script_error")
+@click.group(name="script_error")
 def script_error_group() -> None:
     """Manage ScriptError table"""
 

--- a/src/lsst/cmservice/cli/script_template.py
+++ b/src/lsst/cmservice/cli/script_template.py
@@ -1,11 +1,12 @@
 """CLI to manage ScriptTemplate table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="script_template")
+@click.group(name="script_template")
 def script_template_group() -> None:
     """Manage ScriptTemplate table"""
 

--- a/src/lsst/cmservice/cli/server.py
+++ b/src/lsst/cmservice/cli/server.py
@@ -4,13 +4,13 @@ import uvicorn
 from safir.asyncio import run_with_asyncio
 from safir.database import create_database_engine, initialize_database
 
-from .. import db
+from .. import __version__, db
 from ..config import config
 
 
 # build the server CLI
 @click.group()
-@click.version_option(package_name="lsst-cm-service")
+@click.version_option(version=__version__)
 def server() -> None:
     """Administrative command-line interface for cm-service."""
 
@@ -33,8 +33,5 @@ def run(port: int) -> None:  # pragma: no cover
     uvicorn.run("lsst.cmservice.main:app", host="0.0.0.0", port=port, reload=True, reload_dirs=["src"])
 
 
-# Build the client CLI
-@click.group(name="client")
-@click.version_option(package_name="lsst-cm-service")
-def client_top() -> None:
-    """Administrative command-line interface client-side commands."""
+if __name__ == "__main__":
+    server()

--- a/src/lsst/cmservice/cli/spec_block.py
+++ b/src/lsst/cmservice/cli/spec_block.py
@@ -1,11 +1,12 @@
 """CLI to manage SpecBlock table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="spec_block")
+@click.group(name="spec_block")
 def spec_block_group() -> None:
     """Manage SpecBlock table"""
 

--- a/src/lsst/cmservice/cli/specification.py
+++ b/src/lsst/cmservice/cli/specification.py
@@ -1,11 +1,12 @@
 """CLI to manage Specification table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="specification")
+@click.group(name="specification")
 def specification_group() -> None:
     """Manage Specification table"""
 

--- a/src/lsst/cmservice/cli/step.py
+++ b/src/lsst/cmservice/cli/step.py
@@ -1,11 +1,12 @@
 """CLI to manage Step table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="step")
+@click.group(name="step")
 def step_group() -> None:
     """Manage Step table"""
 

--- a/src/lsst/cmservice/cli/step_dependency.py
+++ b/src/lsst/cmservice/cli/step_dependency.py
@@ -1,11 +1,12 @@
 """CLI to manage Group table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="step_dependency")
+@click.group(name="step_dependency")
 def step_dependency_group() -> None:
     """Manage StepDependency table"""
 

--- a/src/lsst/cmservice/cli/task_set.py
+++ b/src/lsst/cmservice/cli/task_set.py
@@ -1,11 +1,12 @@
 """CLI to manage TaskSet table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="task_set")
+@click.group(name="task_set")
 def task_set_group() -> None:
     """Manage TaskSet table"""
 

--- a/src/lsst/cmservice/cli/wms_task_report.py
+++ b/src/lsst/cmservice/cli/wms_task_report.py
@@ -1,11 +1,12 @@
 """CLI to manage WmsTaskReport table"""
 
+import click
+
 from .. import db
 from . import options, wrappers
-from .commands import client_top
 
 
-@client_top.group(name="wms_task_report")
+@click.group(name="wms_task_report")
 def wms_task_report_group() -> None:
     """Manage WmsTaskReport table"""
 

--- a/tests/cli/test_campaigns.py
+++ b/tests/cli/test_campaigns.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.common.enums import LevelEnum
 from lsst.cmservice.config import config

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,7 +1,8 @@
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
-from lsst.cmservice.cli.commands import client_top, server
+from lsst.cmservice.cli.client import client_top
+from lsst.cmservice.cli.server import server
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 

--- a/tests/cli/test_groups.py
+++ b/tests/cli/test_groups.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.common.enums import LevelEnum
 from lsst.cmservice.config import config

--- a/tests/cli/test_jobs.py
+++ b/tests/cli/test_jobs.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.common.enums import LevelEnum, StatusEnum
 from lsst.cmservice.config import config

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 

--- a/tests/cli/test_productions.py
+++ b/tests/cli/test_productions.py
@@ -4,7 +4,7 @@ import uuid
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.common.enums import LevelEnum
 from lsst.cmservice.config import config

--- a/tests/cli/test_steps.py
+++ b/tests/cli/test_steps.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.common.enums import LevelEnum
 from lsst.cmservice.config import config

--- a/tests/cli/test_trivial.py
+++ b/tests/cli/test_trivial.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
 from lsst.cmservice import models
-from lsst.cmservice.cli.commands import client_top
+from lsst.cmservice.cli.client import client_top
 from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 


### PR DESCRIPTION
- Splits `lsst.cmservice.cli.commands` into separate `.client` and `.server` modules each with a `__main__` entry point.
- Inverts cm client cli dependency injection so subcommand groups are imported by the "parent" command group and not the other way around.
- Remove transitive imports from `lsst.cmservice.cli.__init__.py`.