### PR TITLE
DM-47935 : Use custom JSON Encoder that understands enums

### DIFF
--- a/tests/cli/test_campaigns.py
+++ b/tests/cli/test_campaigns.py
@@ -47,13 +47,13 @@ async def test_campaign_cli(uvicorn: UvicornProcess) -> None:
 
     # test other output cases
     result = runner.invoke(client_top, "campaign list --output json")
-    assert result.exit_code == 1  # FIXME. StatusEnum is not JSON serializable
+    assert result.exit_code == 0
 
     result = runner.invoke(client_top, "campaign list")
     assert result.exit_code == 0
 
     result = runner.invoke(client_top, f"campaign get all --row_id {entry.id} --output json")
-    assert result.exit_code == 1  # FIXME. StatusEnum is not JSON serializable
+    assert result.exit_code == 0
 
     result = runner.invoke(client_top, f"campaign get all --row_id {entry.id}")
     assert result.exit_code == 0


### PR DESCRIPTION
Fixes the `-o json` option for cm-client to properly output JSON where enum types are serialized into objects with both the enum name and value; also ensures that list outputs are a JSON list and that the output is acceptable to a `jq` filter.