### PR TITLE
DM-48001 : Update namespace package definition and suppress type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ python_files = ["tests/*.py", "tests/*/*.py"]
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-ignore_missing_imports = true
+# ignore_missing_imports = true
 local_partial_types = true
 no_implicit_reexport = true
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ python_files = ["tests/*.py", "tests/*/*.py"]
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-# ignore_missing_imports = true
+ignore_missing_imports = true
 local_partial_types = true
 no_implicit_reexport = true
 show_error_codes = true

--- a/src/lsst/__init__.py
+++ b/src/lsst/__init__.py
@@ -1,0 +1,5 @@
+"""LSST Namespace package, pkgutil-style"""
+
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/lsst/cmservice/common/butler.py
+++ b/src/lsst/cmservice/common/butler.py
@@ -1,7 +1,8 @@
 """Utility functions for working with butler commands"""
 
-from lsst.cmservice.common import errors
 from lsst.daf.butler import Butler, MissingCollectionError
+
+from ..common import errors
 
 
 def remove_run_collections(

--- a/src/lsst/cmservice/common/daemon.py
+++ b/src/lsst/cmservice/common/daemon.py
@@ -4,8 +4,8 @@ from time import sleep
 from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
 
-from lsst.cmservice.db.queue import Queue
-from lsst.cmservice.db.script import Script
+from ..db.queue import Queue
+from ..db.script import Script
 
 
 async def daemon_iteration(session: async_scoped_session) -> None:

--- a/src/lsst/cmservice/daemon.py
+++ b/src/lsst/cmservice/daemon.py
@@ -5,8 +5,8 @@ from time import sleep
 import structlog
 from safir.database import create_async_session, create_database_engine
 
-from lsst.cmservice.common.daemon import daemon_iteration
-from lsst.cmservice.config import config
+from .common.daemon import daemon_iteration
+from .config import config
 
 
 async def main_loop() -> None:

--- a/src/lsst/cmservice/handlers/elements.py
+++ b/src/lsst/cmservice/handlers/elements.py
@@ -6,15 +6,15 @@ from typing import Any
 import numpy as np
 from sqlalchemy.ext.asyncio import async_scoped_session
 
-from lsst.cmservice.db.campaign import Campaign
-from lsst.cmservice.db.element import ElementMixin
-from lsst.cmservice.db.group import Group
-from lsst.cmservice.db.job import Job
-from lsst.cmservice.db.script import Script
 from lsst.daf.butler import Butler
 
 from ..common.enums import StatusEnum
 from ..common.errors import CMMissingScriptInputError, test_type_and_raise
+from ..db.campaign import Campaign
+from ..db.element import ElementMixin
+from ..db.group import Group
+from ..db.job import Job
+from ..db.script import Script
 from .script_handler import FunctionHandler
 
 

--- a/src/lsst/cmservice/handlers/scripts.py
+++ b/src/lsst/cmservice/handlers/scripts.py
@@ -6,9 +6,6 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import async_scoped_session
 
-from lsst.cmservice.db.element import ElementMixin
-from lsst.cmservice.db.script import Script
-
 from ..common.bash import write_bash_script
 from ..common.butler import (
     remove_collection_from_chain,
@@ -18,6 +15,8 @@ from ..common.butler import (
 )
 from ..common.enums import LevelEnum, ScriptMethodEnum, StatusEnum
 from ..common.errors import CMBadExecutionMethodError, CMMissingScriptInputError, test_type_and_raise
+from ..db.element import ElementMixin
+from ..db.script import Script
 from ..db.step import Step
 from .script_handler import ScriptHandler
 
@@ -435,7 +434,7 @@ class PrepareStepScriptHandler(ScriptHandler):
 
         prereq_colls: list[str] = []
 
-        all_prereqs = await parent.get_all_prereqs(session)
+        all_prereqs = await parent.get_all_prereqs(session)  # type: ignore
         for prereq_step in all_prereqs:
             prereq_step_colls = await prereq_step.resolve_collections(session)
             prereq_colls.append(prereq_step_colls["step_public_output"])
@@ -493,7 +492,7 @@ class ResourceUsageScriptHandler(ScriptHandler):
             session,
             data_dict["resource_usage_script_template"],
         )
-        prepend = resource_usage_script_template.data["text"].replace(
+        prepend = resource_usage_script_template.data["text"].replace(  # type: ignore
             "{lsst_version}",
             lsst_version,
         )
@@ -562,7 +561,7 @@ class HipsMapsScriptHandler(ScriptHandler):
             session,
             data_dict["hips_maps_script_template"],
         )
-        prepend = hips_maps_script_template.data["text"].replace(
+        prepend = hips_maps_script_template.data["text"].replace(  # type: ignore
             "{lsst_version}",
             lsst_version,
         )

--- a/src/lsst/cmservice/models/queue.py
+++ b/src/lsst/cmservice/models/queue.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
-from lsst.cmservice.common.enums import LevelEnum
+from ..common.enums import LevelEnum
 
 
 class QueueBase(BaseModel):

--- a/src/lsst/cmservice/web_app/pages/campaigns.py
+++ b/src/lsst/cmservice/web_app/pages/campaigns.py
@@ -24,7 +24,7 @@ async def get_campaign_details(session: async_scoped_session, campaign: Campaign
     campaign_details = {
         "id": campaign.id,
         "name": campaign.name,
-        "lsst_version": campaign.data["lsst_version"],
+        "lsst_version": campaign.data["lsst_version"],  # type: ignore
         "out": collections["out"],
         "source": collections.get("campaign_source", ""),
         "status": map_status(campaign.status),

--- a/src/lsst/cmservice/web_app/pages/steps.py
+++ b/src/lsst/cmservice/web_app/pages/steps.py
@@ -17,7 +17,7 @@ async def get_campaign_steps(session: async_scoped_session, campaign_id: int) ->
 
 async def get_step_details(session: async_scoped_session, step: Step) -> dict:
     step_groups = await step.children(session)
-    no_groups = len(step_groups)
+    no_groups = len(list(step_groups))
     no_groups_completed = len([group for group in step_groups if group.status == StatusEnum.accepted])
     no_groups_need_attention = len(
         [group for group in step_groups if map_status(group.status) == "NEED_ATTENTION"],
@@ -36,7 +36,7 @@ async def get_step_details(session: async_scoped_session, step: Step) -> dict:
     return step_details
 
 
-async def get_campaign_by_id(session: async_scoped_session, campaign_id: int) -> Campaign:
+async def get_campaign_by_id(session: async_scoped_session, campaign_id: int) -> Campaign | None:
     q = select(Campaign).where(Campaign.id == campaign_id)
     async with session.begin_nested():
         results = await session.scalars(q)

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -20,21 +20,21 @@ async def test_others_cli(uvicorn: UvicornProcess) -> None:
     assert len(check) == 0
 
     result = runner.invoke(client_top, "product_set list --output yaml")
-    check = check_and_parse_result(result, list[models.ProductSet])
+    check = check_and_parse_result(result, list[models.ProductSet])  # type: ignore
     assert len(check) == 0
 
     result = runner.invoke(client_top, "script_dependency list --output yaml")
-    check = check_and_parse_result(result, list[models.Dependency])
+    check = check_and_parse_result(result, list[models.Dependency])  # type: ignore
     assert len(check) == 0
 
     result = runner.invoke(client_top, "script_error list --output yaml")
-    check = check_and_parse_result(result, list[models.ScriptError])
+    check = check_and_parse_result(result, list[models.ScriptError])  # type: ignore
     assert len(check) == 0
 
     result = runner.invoke(client_top, "task_set list --output yaml")
-    check = check_and_parse_result(result, list[models.TaskSet])
+    check = check_and_parse_result(result, list[models.TaskSet])  # type: ignore
     assert len(check) == 0
 
     result = runner.invoke(client_top, "wms_task_report list --output yaml")
-    check = check_and_parse_result(result, list[models.WmsTaskReport])
+    check = check_and_parse_result(result, list[models.WmsTaskReport])  # type: ignore
     assert len(check) == 0

--- a/tests/cli/util_functions.py
+++ b/tests/cli/util_functions.py
@@ -33,7 +33,7 @@ def add_scripts(
     runner: CliRunner,
     client_top: BaseCommand,
     element: models.ElementMixin,
-) -> tuple[list[models.Script], models.Dependency]:
+) -> tuple[list[models.Script], models.Dependency | None]:
     result = runner.invoke(
         client_top,
         "script create "
@@ -444,7 +444,7 @@ def check_get_methods(
     check_get = check_and_parse_result(result, entry_class)
 
     assert check_get.id == entry.id, "pulled row should be identical"
-    assert check_get.level == entry.level, "pulled row db_id should be identical"
+    assert check_get.level == entry.level, "pulled row db_id should be identical"  # type: ignore
 
     result = runner.invoke(client_top, f"{entry_class_name} get by_name --output yaml --name {entry.name}")
     check_get = check_and_parse_result(result, entry_class)

--- a/tests/db/test_group.py
+++ b/tests/db/test_group.py
@@ -70,8 +70,8 @@ async def test_group_db(engine: AsyncEngine) -> None:
         check = await entry.get_campaign(session)
         assert check.name == f"camp0_{uuid_int}", "should return same name as camp0"
 
-        check = await entry.children(session)
-        assert len(list(check)) == 1, "length of children should be 1"
+        check = await entry.children(session)  # type: ignore
+        assert len(list(check)) == 1, "length of children should be 1"  # type: ignore
 
         # check update methods
         await check_update_methods(session, entry, db.Group)

--- a/tests/db/test_handlers.py
+++ b/tests/db/test_handlers.py
@@ -371,7 +371,7 @@ async def test_handlers_job_level_db(
         )
         assert status == StatusEnum.waiting
 
-        assert jobs.PandaScriptHandler.get_job_id({"Run Id": 322}) == 322
+        assert jobs.PandaScriptHandler.get_job_id({"Run Id": 322}) == 322  # type: ignore
         assert jobs.HTCondorScriptHandler.get_job_id({"Submit dir": "dummy"}) == "dummy"
 
         await cleanup(session, check_cascade=True)

--- a/tests/db/test_job.py
+++ b/tests/db/test_job.py
@@ -81,7 +81,7 @@ async def test_job_db(engine: AsyncEngine) -> None:
         check = await entry.get_siblings(session)
         assert len(list(check)) == 0, "length of siblings should be 0"
 
-        check = await entry.get_errors(session)
+        check = await entry.get_errors(session)  # type: ignore
         assert len(check) == 0, "length of errors should be 0"
 
         sleep_time = await campaign.estimate_sleep_time(session)
@@ -95,42 +95,42 @@ async def test_job_db(engine: AsyncEngine) -> None:
 
         # check on the rescue job
         with pytest.raises(errors.CMTooFewAcceptedJobsError):
-            await parent.rescue_job(session)
+            await parent.rescue_job(session)  # type: ignore
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.rescuable)
-        job2 = await parent.rescue_job(session)
+        job2 = await parent.rescue_job(session)  # type: ignore
 
         with pytest.raises(errors.CMBadStateTransitionError):
-            await parent.mark_job_rescued(session)
+            await parent.mark_job_rescued(session)  # type: ignore
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.rescuable)
         with pytest.raises(errors.CMBadStateTransitionError):
-            await parent.mark_job_rescued(session)
+            await parent.mark_job_rescued(session)  # type: ignore
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.rescuable)
         await db.Job.update_row(session, job2.id, status=StatusEnum.accepted)
 
-        rescued = await parent.mark_job_rescued(session)
+        rescued = await parent.mark_job_rescued(session)  # type: ignore
         assert len(rescued) == 1, "Wrong number of rescued jobs"
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.accepted)
         await db.Job.update_row(session, job2.id, status=StatusEnum.accepted)
         with pytest.raises(errors.CMTooManyActiveScriptsError):
-            await parent.mark_job_rescued(session)
+            await parent.mark_job_rescued(session)  # type: ignore
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.rescuable)
         await db.Job.update_row(session, job2.id, status=StatusEnum.rescuable)
 
-        job3 = await parent.rescue_job(session)
+        job3 = await parent.rescue_job(session)  # type: ignore
 
         await db.Job.update_row(session, entry.id, status=StatusEnum.rescued)
         await db.Job.update_row(session, job2.id, status=StatusEnum.failed, superseded=True)
         await db.Job.update_row(session, job3.id, status=StatusEnum.rescuable)
 
         with pytest.raises(errors.CMTooFewAcceptedJobsError):
-            await parent.mark_job_rescued(session)
+            await parent.mark_job_rescued(session)  # type: ignore
 
-        job4 = await parent.rescue_job(session)
+        job4 = await parent.rescue_job(session)  # type: ignore
         await db.Job.update_row(session, job4.id, status=StatusEnum.accepted)
 
         rescued = await interface.mark_job_rescued(session, parent.fullname)

--- a/tests/db/test_reports.py
+++ b/tests/db/test_reports.py
@@ -98,7 +98,7 @@ async def test_reports_db(engine: AsyncEngine) -> None:
             status=StatusEnum.rescuable,
         )
 
-        job2 = await parent.rescue_job(session)
+        job2 = await parent.rescue_job(session)  # type: ignore
 
         await interface.load_manifest_report(
             session,
@@ -117,7 +117,7 @@ async def test_reports_db(engine: AsyncEngine) -> None:
         assert status_check == StatusEnum.failed
         await db.Job.update_row(session, job2.id, superseded=True)
 
-        job3 = await parent.rescue_job(session)
+        job3 = await parent.rescue_job(session)  # type: ignore
 
         await interface.load_manifest_report(
             session,
@@ -137,7 +137,7 @@ async def test_reports_db(engine: AsyncEngine) -> None:
 
         await db.Job.update_row(session, job3.id, status=StatusEnum.rescuable)
 
-        job4 = await parent.rescue_job(session)
+        job4 = await parent.rescue_job(session)  # type: ignore
         await interface.load_manifest_report(
             session,
             "examples/manifest_report_accept_error.yaml",
@@ -154,7 +154,7 @@ async def test_reports_db(engine: AsyncEngine) -> None:
         )
         assert status_check == StatusEnum.accepted
 
-        await parent.mark_job_rescued(session)
+        await parent.mark_job_rescued(session)  # type: ignore
 
         # cleanup
         await cleanup(session)

--- a/tests/db/test_step.py
+++ b/tests/db/test_step.py
@@ -67,14 +67,14 @@ async def test_step_db(engine: AsyncEngine) -> None:
             await db.Step.delete_row(session, -99)
 
         # run step specific method tests
-        check = await entry.get_campaign(session)
-        assert check.name == f"camp0_{uuid_int}", "should return same name as camp0"
+        check1 = await entry.get_campaign(session)
+        assert check1.name == f"camp0_{uuid_int}", "should return same name as camp0"
 
-        check = await entry.get_all_prereqs(session)
-        assert len(check) == 1, "should be one prereq"
+        check2 = await entry.get_all_prereqs(session)
+        assert len(check2) == 1, "should be one prereq"
 
-        check = await entry.children(session)
-        assert len(list(check)) == 5, "length of children should be 5"
+        check3 = await entry.children(session)
+        assert len(list(check3)) == 5, "length of children should be 5"
 
         # check update methods
         await check_update_methods(session, entry, db.Step)

--- a/tests/db/util_functions.py
+++ b/tests/db/util_functions.py
@@ -408,7 +408,7 @@ async def check_get_methods(
         await interface.get_row_by_table_and_id(session, entry.id, TableEnum.n_tables)
 
     with pytest.raises(errors.CMMissingFullnameError):
-        await interface.get_row_by_table_and_id(session, -99, TableEnum[entry.__tablename__])
+        await interface.get_row_by_table_and_id(session, -99, TableEnum[entry.__tablename__])  # type: ignore
 
     with pytest.raises(errors.CMBadEnumError):
         await interface.get_node_by_level_and_id(session, entry.id, LevelEnum.n_levels)
@@ -419,7 +419,7 @@ async def check_get_methods(
     check = await interface.get_row_by_table_and_id(
         session,
         entry.id,
-        TableEnum[entry.__tablename__],
+        TableEnum[entry.__tablename__],  # type: ignore
     )
     assert check.fullname == entry.fullname
 
@@ -436,14 +436,14 @@ async def check_get_methods(
     specification_check = await entry.get_specification(session)
     assert specification_check.name
 
-    check = await entry.get_tasks(session)
-    assert len(check.reports) == 0, "length of tasks should be 0"
+    check1 = await entry.get_tasks(session)
+    assert len(check1.reports) == 0, "length of tasks should be 0"
 
-    check = await entry.get_wms_reports(session)
-    assert len(check.reports) == 0, "length of reports should be 0"
+    check2 = await entry.get_wms_reports(session)
+    assert len(check2.reports) == 0, "length of reports should be 0"
 
-    check = await entry.get_products(session)
-    assert len(check.reports) == 0, "length of products should be 0"
+    check3 = await entry.get_products(session)
+    assert len(check3.reports) == 0, "length of products should be 0"
 
     sleep_time = await entry.estimate_sleep_time(session)
     assert sleep_time == 10, "Wrong sleep time"

--- a/tests/routers/util_functions.py
+++ b/tests/routers/util_functions.py
@@ -35,7 +35,7 @@ async def add_scripts(
     prep_script_model = models.ScriptCreate(
         name="prepare",
         parent_name=element.fullname,
-        parent_level=element.level.value,
+        parent_level=element.level.value,  # type: ignore
         spec_block_name="null_script",
     )
 
@@ -48,7 +48,7 @@ async def add_scripts(
     collect_script_model = models.ScriptCreate(
         name="collect",
         parent_name=element.fullname,
-        parent_level=element.level.value,
+        parent_level=element.level.value,  # type: ignore
         spec_block_name="null_script",
     )
     response = await client.post(
@@ -432,7 +432,7 @@ async def check_update_methods(
     check_process = check_and_parse_response(response, tuple[bool, StatusEnum])
     assert check_process[1] == StatusEnum.running
 
-    process_query.fake_status = StatusEnum.running
+    process_query.fake_status = StatusEnum.running.value
     response = await client.post(
         f"{config.prefix}/actions/process",
         content=process_query.model_dump_json(),
@@ -540,20 +540,20 @@ async def check_scripts(
     no_scripts = check_and_parse_response(response, list[models.Script])
     assert len(no_scripts) == 0, "get_scripts with bad script_name did not return []"
 
-    query_model = models.ScriptQuery(
+    query_model1 = models.ScriptQuery(
         fullname=entry.fullname,
         script_name=None,
     )
     response = await client.get(
         f"{config.prefix}/{entry_class_name}/get/{entry.id}/all_scripts",
-        params=query_model.model_dump(),
+        params=query_model1.model_dump(),
     )
     all_scripts = check_and_parse_response(response, list[models.Script])
     assert len(all_scripts) != 0, "get_all_scripts with failed"
 
     response = await client.get(
         f"{config.prefix}/{entry_class_name}/get/-1/all_scripts",
-        params=query_model.model_dump(),
+        params=query_model1.model_dump(),
     )
     expect_failed_response(response, 404)
 
@@ -597,7 +597,7 @@ async def check_scripts(
     )
     expect_failed_response(response, 404)
 
-    query_model = models.RetryScriptQuery(
+    query_model2 = models.RetryScriptQuery(
         fullname=entry.fullname,
         script_name="prepare",
         fake_reset=True,
@@ -606,14 +606,14 @@ async def check_scripts(
 
     response = await client.post(
         f"{config.prefix}/{entry_class_name}/action/{entry.id}/retry_script",
-        content=query_model.model_dump_json(),
+        content=query_model2.model_dump_json(),
     )
     retry_check = check_and_parse_response(response, models.Script)
     assert retry_check.status == StatusEnum.waiting
 
     response = await client.post(
         f"{config.prefix}/{entry_class_name}/action/-1/retry_script",
-        content=query_model.model_dump_json(),
+        content=query_model2.model_dump_json(),
     )
     expect_failed_response(response, 404)
 
@@ -685,7 +685,7 @@ async def check_get_methods(
     check_get = check_and_parse_response(response, entry_class)
 
     assert check_get.id == entry.id, "pulled row should be identical"
-    assert check_get.level == entry.level, "pulled row db_id should be identical"
+    assert check_get.level == entry.level, "pulled row db_id should be identical"  # type: ignore
 
     response = await client.get(f"{config.prefix}/{entry_class_name}/get/-1")
     expect_failed_response(response, 404)
@@ -745,8 +745,8 @@ async def check_get_methods(
     response = await client.get(
         f"{config.prefix}/{entry_class_name}/get/{entry.id}/tasks",
     )
-    check = check_and_parse_response(response, models.MergedTaskSetDict)
-    assert len(check.reports) == 0, "length of tasks should be 0"
+    check1 = check_and_parse_response(response, models.MergedTaskSetDict)
+    assert len(check1.reports) == 0, "length of tasks should be 0"
 
     response = await client.get(f"{config.prefix}/{entry_class_name}/get/-1/tasks")
     expect_failed_response(response, 404)
@@ -754,17 +754,17 @@ async def check_get_methods(
     response = await client.get(
         f"{config.prefix}/{entry_class_name}/get/{entry.id}/wms_task_reports",
     )
-    check = check_and_parse_response(response, models.MergedWmsTaskReportDict)
+    check2 = check_and_parse_response(response, models.MergedWmsTaskReportDict)
 
-    assert len(check.reports) == 0, "length of reports should be 0"
+    assert len(check2.reports) == 0, "length of reports should be 0"
     response = await client.get(f"{config.prefix}/{entry_class_name}/get/-1/wms_task_reports")
     expect_failed_response(response, 404)
 
     response = await client.get(
         f"{config.prefix}/{entry_class_name}/get/{entry.id}/products",
     )
-    check = check_and_parse_response(response, models.MergedProductSetDict)
-    assert len(check.reports) == 0, "length of products should be 0"
+    check3 = check_and_parse_response(response, models.MergedProductSetDict)
+    assert len(check3.reports) == 0, "length of products should be 0"
 
     response = await client.get(f"{config.prefix}/{entry_class_name}/get/-1/products")
     expect_failed_response(response, 404)

--- a/tests/web_app/test_group_details_page.py
+++ b/tests/web_app/test_group_details_page.py
@@ -29,8 +29,8 @@ async def test_get_group_details_by_id(engine: AsyncEngine) -> None:
         await create_tree(session, LevelEnum.job, uuid_int)
 
         group, group_jobs, group_scripts = await get_group_by_id(session, 1)
-        assert len(group_scripts) == 2
-        assert len(group_jobs) == 1
+        assert group_scripts is not None and len(group_scripts) == 2
+        assert group_jobs is not None and len(group_jobs) == 1
 
         assert group == {
             "id": 1,

--- a/tests/web_app/test_job_details_page.py
+++ b/tests/web_app/test_job_details_page.py
@@ -29,7 +29,7 @@ async def test_get_job_by_id(engine: AsyncEngine) -> None:
         await create_tree(session, LevelEnum.job, uuid_int)
 
         job, job_scripts = await get_job_by_id(session, 1)
-        assert len(job_scripts) == 2
+        assert job_scripts is not None and len(job_scripts) == 2
 
         assert job == {
             "id": 1,


### PR DESCRIPTION
- Makes `lsst/cmservice` a "pkg-util-style" namespace package consistent with other Python packages in the `lsst` namespace.
- Fixes "new" mypy typing errors that are trivial.
- Suppresses "new" mypy typing errors.
- Changes absolute `lsst.cmservice.*` imports to relative imports (except in `**/web_app/`)

Previous mypy successes have been false positives because any `lsst.cmservice.*` modules imported with absolute references could not be found by mypy (or pylance) because, presumably, of the namespace packaging mismatch between cmservice and other lsst namespace packages added as dependencies.

Any "new" mypy errors following this correction to namespace packaging have been previously suppressed by mypy config and are now suppressed by `# type: ignore` directives so they may be located and corrected in future work.

Note: pylance reports more type errors than mypy does, but any suppression in this PR is according to the output of `make typing` and not pylance.