### PR TITLE
DM-47219 Reset a script through the web app

### DIFF
--- a/src/lsst/cmservice/web_app/app.py
+++ b/src/lsst/cmservice/web_app/app.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.http_client import http_client_dependency
 from sqlalchemy.ext.asyncio import async_scoped_session
-from starlette.responses import JSONResponse
 
 from lsst.cmservice import db
 from lsst.cmservice.config import config
@@ -261,54 +260,12 @@ async def test_layout(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("pages/mockup.html", {"request": request})
 
 
-@web_app.get("/test-ag-grid/", response_class=HTMLResponse)
-async def test_ag_grid(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse("pages/test-ag-grid.html", {"request": request})
-
-
-@web_app.get("/modal", response_class=HTMLResponse)
-async def modal(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse(
-        name="partials/test_modal.html",
-        request=request,
-        context={"script": {"id": 1, "fullname": "fullname", "log_url": "/hello/script"}},
-    )
-
-
-# WORKING
-class ResetScriptRequest(BaseModel):
-    id: Annotated[str, Form()]
-    fullname: Annotated[str, Form()]
-    to_status: Annotated[str, Form()]
-
-
-@web_app.post("/my-reset-script/", response_class=JSONResponse)
-async def my_reset_script(
-    request: Request,
-    id: Annotated[str, Form()],
-    fullname: Annotated[str, Form()],
-    to_status: Annotated[str, Form()],
-):
-    print(f"reset script: {id}, {fullname} to {to_status}")
-    # Example response
-    return JSONResponse(content={"id": id, "status": to_status}, status_code=201)
-
-
-@web_app.get("/reset_modal", response_class=HTMLResponse)
-async def reset_modal(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse(
-        name="partials/test_reset_modal.html",
-        request=request,
-        context={"script": {"id": 1, "fullname": "fullname", "log_url": "/hello/script"}},
-    )
-
-
 class ReadScriptLogRequest(BaseModel):
     log_path: str
 
 
 @web_app.post("/read-script-log")
-async def read_script_log(request: ReadScriptLogRequest):
+async def read_script_log(request: ReadScriptLogRequest) -> dict[str, str]:
     file_path = Path(request.log_path)
 
     # Check if the file exists

--- a/src/lsst/cmservice/web_app/app.py
+++ b/src/lsst/cmservice/web_app/app.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends, FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+
+# from pydantic import BaseModel
 from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.http_client import http_client_dependency
 from sqlalchemy.ext.asyncio import async_scoped_session
@@ -257,3 +259,38 @@ async def get_script(
 @web_app.get("/layout/", response_class=HTMLResponse)
 async def test_layout(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("pages/mockup.html", {"request": request})
+
+
+@web_app.get("/test-ag-grid/", response_class=HTMLResponse)
+async def test_ag_grid(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("pages/test-ag-grid.html", {"request": request})
+
+
+# NOT WORKING
+# @web_app.post("/my-reset-script/", response_class=JSONResponse)
+# async def my_reset_script(
+#         request: Request,
+#         response: Response,
+#         # script_id: Annotated[int, Form()],
+#         targetStatus: Annotated[str, Form()],
+#         session: async_scoped_session = Depends(db_session_dependency)
+# ) -> dict:
+#     print(f"Resetting script to {targetStatus}")
+#     data = {"status": targetStatus}
+#     response.status_code = status.HTTP_201_CREATED
+#     return data
+
+
+# WORKING
+# class ResetScriptRequest(BaseModel):
+#     id: int
+#     to_status: int
+#
+#
+# @web_app.post("/my-reset-script/", response_class=JSONResponse)
+# async def my_reset_script(request: ResetScriptRequest):
+#     # Example response
+#     return JSONResponse(
+#         content={"id": request.id, "status": request.to_status},
+#         status_code=201
+#     )

--- a/src/lsst/cmservice/web_app/pages/group_details.py
+++ b/src/lsst/cmservice/web_app/pages/group_details.py
@@ -106,8 +106,9 @@ async def get_group_scripts(session: async_scoped_session, group: Group) -> list
             {
                 "id": script.id,
                 "name": script.name,
+                "fullname": script.fullname,
                 "superseded": script.superseded,
-                "status": map_status(script.status),
+                "status": str(script.status.name).upper(),
             },
         )
     return step_scripts

--- a/src/lsst/cmservice/web_app/pages/group_details.py
+++ b/src/lsst/cmservice/web_app/pages/group_details.py
@@ -109,6 +109,7 @@ async def get_group_scripts(session: async_scoped_session, group: Group) -> list
                 "fullname": script.fullname,
                 "superseded": script.superseded,
                 "status": str(script.status.name).upper(),
+                "log_url": script.log_url,
             },
         )
     return step_scripts

--- a/src/lsst/cmservice/web_app/pages/job_details.py
+++ b/src/lsst/cmservice/web_app/pages/job_details.py
@@ -79,8 +79,9 @@ async def get_job_scripts(session: async_scoped_session, job: Job) -> list[dict]
             {
                 "id": script.id,
                 "name": script.name,
+                "fullname": script.fullname,
                 "superseded": script.superseded,
-                "status": map_status(script.status),
+                "status": str(script.status.name).upper(),
             },
         )
     return job_scripts

--- a/src/lsst/cmservice/web_app/pages/job_details.py
+++ b/src/lsst/cmservice/web_app/pages/job_details.py
@@ -82,6 +82,7 @@ async def get_job_scripts(session: async_scoped_session, job: Job) -> list[dict]
                 "fullname": script.fullname,
                 "superseded": script.superseded,
                 "status": str(script.status.name).upper(),
+                "log_url": script.log_url,
             },
         )
     return job_scripts

--- a/src/lsst/cmservice/web_app/pages/step_details.py
+++ b/src/lsst/cmservice/web_app/pages/step_details.py
@@ -52,7 +52,7 @@ async def get_step_scripts(session: async_scoped_session, step: Step) -> list[di
                 "name": script.name,
                 "fullname": script.fullname,
                 "superseded": script.superseded,
-                "status": map_status(script.status),
+                "status": str(script.status.name).upper(),
             },
         )
     return step_scripts

--- a/src/lsst/cmservice/web_app/pages/step_details.py
+++ b/src/lsst/cmservice/web_app/pages/step_details.py
@@ -53,6 +53,7 @@ async def get_step_scripts(session: async_scoped_session, step: Step) -> list[di
                 "fullname": script.fullname,
                 "superseded": script.superseded,
                 "status": str(script.status.name).upper(),
+                "log_url": script.log_url,
             },
         )
     return step_scripts

--- a/src/lsst/cmservice/web_app/pages/step_details.py
+++ b/src/lsst/cmservice/web_app/pages/step_details.py
@@ -50,6 +50,7 @@ async def get_step_scripts(session: async_scoped_session, step: Step) -> list[di
             {
                 "id": script.id,
                 "name": script.name,
+                "fullname": script.fullname,
                 "superseded": script.superseded,
                 "status": map_status(script.status),
             },

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -1851,6 +1851,11 @@ video {
   --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
 }
 
+.focus\:ring-indigo-600:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(79 70 229 / var(--tw-ring-opacity));
+}
+
 .focus\:ring-offset-2:focus {
   --tw-ring-offset-width: 2px;
 }

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -826,6 +826,24 @@ video {
   height: 100%;
 }
 
+.h-5\/6 {
+  height: 83.333333%;
+}
+
+.h-max {
+  height: -moz-max-content;
+  height: max-content;
+}
+
+.h-fit {
+  height: -moz-fit-content;
+  height: fit-content;
+}
+
+.h-3\/4 {
+  height: 75%;
+}
+
 .min-h-full {
   min-height: 100%;
 }
@@ -1565,6 +1583,18 @@ video {
   outline-style: solid;
 }
 
+.outline-1 {
+  outline-width: 1px;
+}
+
+.-outline-offset-1 {
+  outline-offset: -1px;
+}
+
+.outline-gray-300 {
+  outline-color: #d1d5db;
+}
+
 .ring-1 {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -1597,11 +1627,6 @@ video {
 .ring-teal-600 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
-}
-
-.ring-gray-500 {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(107 114 128 / var(--tw-ring-opacity));
 }
 
 .ring-opacity-5 {
@@ -1697,6 +1722,16 @@ video {
   z-index: 100;
 }
 
+.placeholder\:text-gray-400::-moz-placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity));
+}
+
+.placeholder\:text-gray-400::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity));
+}
+
 .placeholder\:text-teal-500::-moz-placeholder {
   --tw-text-opacity: 1;
   color: rgb(20 184 166 / var(--tw-text-opacity));
@@ -1774,6 +1809,26 @@ video {
 .focus\:outline-none:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;
+}
+
+.focus\:outline:focus {
+  outline-style: solid;
+}
+
+.focus\:outline-2:focus {
+  outline-width: 2px;
+}
+
+.focus\:-outline-offset-2:focus {
+  outline-offset: -2px;
+}
+
+.focus\:outline-indigo-600:focus {
+  outline-color: #4f46e5;
+}
+
+.focus\:outline-teal-600:focus {
+  outline-color: #0d9488;
 }
 
 .focus\:ring-2:focus {

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -651,6 +651,10 @@ video {
   left: 0px;
 }
 
+.left-2 {
+  left: 0.5rem;
+}
+
 .right-0 {
   right: 0px;
 }
@@ -665,10 +669,6 @@ video {
 
 .top-6 {
   top: 1.5rem;
-}
-
-.left-2 {
-  left: 0.5rem;
 }
 
 .z-10 {
@@ -784,6 +784,16 @@ video {
   display: none;
 }
 
+.size-12 {
+  width: 3rem;
+  height: 3rem;
+}
+
+.size-6 {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
 .h-10 {
   height: 2.5rem;
 }
@@ -810,6 +820,10 @@ video {
 
 .h-full {
   height: 100%;
+}
+
+.h-32 {
+  height: 8rem;
 }
 
 .min-h-full {
@@ -844,12 +858,24 @@ video {
   width: 2rem;
 }
 
+.w-96 {
+  width: 24rem;
+}
+
 .w-auto {
   width: auto;
 }
 
 .w-full {
   width: 100%;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.w-screen {
+  width: 100vw;
 }
 
 .max-w-7xl {
@@ -874,6 +900,16 @@ video {
 
 .origin-top-right {
   transform-origin: top right;
+}
+
+.translate-y-0 {
+  --tw-translate-y: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-y-4 {
+  --tw-translate-y: 1rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .scale-100 {
@@ -902,6 +938,10 @@ video {
 
 .flex-wrap {
   flex-wrap: wrap;
+}
+
+.items-end {
+  align-items: flex-end;
 }
 
 .items-center {
@@ -972,6 +1012,10 @@ video {
 
 .overflow-hidden {
   overflow: hidden;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
 }
 
 .truncate {
@@ -1118,6 +1162,30 @@ video {
   background-color: rgb(253 224 71 / var(--tw-bg-opacity));
 }
 
+.bg-teal-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(45 212 191 / var(--tw-bg-opacity));
+}
+
+.bg-teal-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(20 184 166 / var(--tw-bg-opacity));
+}
+
+.bg-gray-500\/75 {
+  background-color: rgb(107 114 128 / 0.75);
+}
+
+.bg-green-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
+}
+
+.bg-indigo-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
+}
+
 .p-1 {
   padding: 0.25rem;
 }
@@ -1132,6 +1200,10 @@ video {
 
 .p-6 {
   padding: 1.5rem;
+}
+
+.p-4 {
+  padding: 1rem;
 }
 
 .px-1 {
@@ -1194,6 +1266,11 @@ video {
   padding-bottom: 1.25rem;
 }
 
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
 .pb-3 {
   padding-bottom: 0.75rem;
 }
@@ -1234,6 +1311,18 @@ video {
   padding-top: 2rem;
 }
 
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
 .font-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
@@ -1261,6 +1350,11 @@ video {
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
+}
+
+.text-sm\/6 {
+  font-size: 0.875rem;
+  line-height: 1.5rem;
 }
 
 .font-bold {
@@ -1387,6 +1481,16 @@ video {
   color: rgb(15 118 110 / var(--tw-text-opacity));
 }
 
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
 .underline {
   text-decoration-line: underline;
 }
@@ -1430,6 +1534,12 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .outline {
   outline-style: solid;
 }
@@ -1456,6 +1566,16 @@ video {
 .ring-teal-600 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
+}
+
+.ring-gray-300 {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(209 213 219 / var(--tw-ring-opacity));
+}
+
+.ring-gray-700 {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(55 65 81 / var(--tw-ring-opacity));
 }
 
 .ring-opacity-5 {
@@ -1499,6 +1619,18 @@ video {
   transition-duration: 150ms;
 }
 
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .duration-200 {
   transition-duration: 200ms;
 }
@@ -1507,16 +1639,20 @@ video {
   transition-duration: 75ms;
 }
 
+.duration-300 {
+  transition-duration: 300ms;
+}
+
 .ease-in {
   transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
 }
 
-.ease-out {
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-}
-
 .ease-in-out {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
 @tailwind forms;
@@ -1575,6 +1711,16 @@ video {
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-indigo-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(99 102 241 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-teal-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(20 184 166 / var(--tw-bg-opacity));
+}
+
 .hover\:font-bold:hover {
   font-weight: 700;
 }
@@ -1599,11 +1745,6 @@ video {
   color: rgb(20 184 166 / var(--tw-text-opacity));
 }
 
-.hover\:text-teal-700:hover {
-  --tw-text-opacity: 1;
-  color: rgb(15 118 110 / var(--tw-text-opacity));
-}
-
 .focus\:outline-none:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -1615,23 +1756,86 @@ video {
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
+.focus\:ring-inset:focus {
+  --tw-ring-inset: inset;
+}
+
 .focus\:ring-indigo-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-indigo-600:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(79 70 229 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-teal-600:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
 }
 
 .focus\:ring-offset-2:focus {
   --tw-ring-offset-width: 2px;
 }
 
+.focus-visible\:outline:focus-visible {
+  outline-style: solid;
+}
+
+.focus-visible\:outline-2:focus-visible {
+  outline-width: 2px;
+}
+
+.focus-visible\:outline-offset-2:focus-visible {
+  outline-offset: 2px;
+}
+
+.focus-visible\:outline-indigo-600:focus-visible {
+  outline-color: #4f46e5;
+}
+
+.focus-visible\:outline-teal-600:focus-visible {
+  outline-color: #0d9488;
+}
+
 @media (min-width: 640px) {
+  .sm\:col-span-3 {
+    grid-column: span 3 / span 3;
+  }
+
+  .sm\:col-start-1 {
+    grid-column-start: 1;
+  }
+
+  .sm\:col-start-2 {
+    grid-column-start: 2;
+  }
+
   .sm\:-my-px {
     margin-top: -1px;
     margin-bottom: -1px;
   }
 
+  .sm\:my-8 {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
   .sm\:ml-6 {
     margin-left: 1.5rem;
+  }
+
+  .sm\:mt-5 {
+    margin-top: 1.25rem;
+  }
+
+  .sm\:mt-6 {
+    margin-top: 1.5rem;
+  }
+
+  .sm\:mt-0 {
+    margin-top: 0px;
   }
 
   .sm\:flex {
@@ -1644,6 +1848,39 @@ video {
 
   .sm\:hidden {
     display: none;
+  }
+
+  .sm\:w-full {
+    width: 100%;
+  }
+
+  .sm\:max-w-sm {
+    max-width: 24rem;
+  }
+
+  .sm\:max-w-xs {
+    max-width: 20rem;
+  }
+
+  .sm\:translate-y-0 {
+    --tw-translate-y: 0px;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:scale-100 {
+    --tw-scale-x: 1;
+    --tw-scale-y: 1;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:scale-95 {
+    --tw-scale-x: .95;
+    --tw-scale-y: .95;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:grid-flow-row-dense {
+    grid-auto-flow: row dense;
   }
 
   .sm\:grid-cols-1 {
@@ -1670,6 +1907,10 @@ video {
     gap: 1px;
   }
 
+  .sm\:gap-3 {
+    gap: 0.75rem;
+  }
+
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-x-reverse: 0;
     margin-right: calc(2rem * var(--tw-space-x-reverse));
@@ -1690,6 +1931,10 @@ video {
     padding: 1.5rem;
   }
 
+  .sm\:p-0 {
+    padding: 0px;
+  }
+
   .sm\:px-4 {
     padding-left: 1rem;
     padding-right: 1rem;
@@ -1703,6 +1948,11 @@ video {
   .sm\:text-sm {
     font-size: 0.875rem;
     line-height: 1.25rem;
+  }
+
+  .sm\:text-sm\/6 {
+    font-size: 0.875rem;
+    line-height: 1.5rem;
   }
 
   .sm\:leading-6 {

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -802,6 +802,10 @@ video {
   height: 4rem;
 }
 
+.h-32 {
+  height: 8rem;
+}
+
 .h-5 {
   height: 1.25rem;
 }
@@ -820,10 +824,6 @@ video {
 
 .h-full {
   height: 100%;
-}
-
-.h-32 {
-  height: 8rem;
 }
 
 .min-h-full {
@@ -854,12 +854,12 @@ video {
   width: 1.5rem;
 }
 
-.w-8 {
-  width: 2rem;
+.w-64 {
+  width: 16rem;
 }
 
-.w-96 {
-  width: 24rem;
+.w-8 {
+  width: 2rem;
 }
 
 .w-auto {
@@ -868,10 +868,6 @@ video {
 
 .w-full {
   width: 100%;
-}
-
-.w-64 {
-  width: 16rem;
 }
 
 .w-screen {
@@ -1126,6 +1122,10 @@ video {
   background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
 
+.bg-gray-500\/75 {
+  background-color: rgb(107 114 128 / 0.75);
+}
+
 .bg-green-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(240 253 244 / var(--tw-bg-opacity));
@@ -1141,6 +1141,16 @@ video {
   background-color: rgb(238 242 255 / var(--tw-bg-opacity));
 }
 
+.bg-indigo-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
+}
+
+.bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+}
+
 .bg-red-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 38 38 / var(--tw-bg-opacity));
@@ -1149,6 +1159,11 @@ video {
 .bg-teal-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(240 253 250 / var(--tw-bg-opacity));
+}
+
+.bg-teal-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(20 184 166 / var(--tw-bg-opacity));
 }
 
 .bg-teal-700 {
@@ -1166,35 +1181,6 @@ video {
   background-color: rgb(253 224 71 / var(--tw-bg-opacity));
 }
 
-.bg-teal-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(45 212 191 / var(--tw-bg-opacity));
-}
-
-.bg-teal-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(20 184 166 / var(--tw-bg-opacity));
-}
-
-.bg-gray-500\/75 {
-  background-color: rgb(107 114 128 / 0.75);
-}
-
-.bg-green-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
-}
-
-.bg-indigo-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
-}
-
-.bg-red-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
-}
-
 .p-1 {
   padding: 0.25rem;
 }
@@ -1207,12 +1193,12 @@ video {
   padding: 0.75rem;
 }
 
-.p-6 {
-  padding: 1.5rem;
-}
-
 .p-4 {
   padding: 1rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
 }
 
 .px-1 {
@@ -1228,6 +1214,11 @@ video {
 .px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .px-4 {
@@ -1275,13 +1266,12 @@ video {
   padding-bottom: 1.25rem;
 }
 
-.px-3 {
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-}
-
 .pb-3 {
   padding-bottom: 0.75rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
 }
 
 .pl-10 {
@@ -1320,10 +1310,6 @@ video {
   padding-top: 2rem;
 }
 
-.pb-4 {
-  padding-bottom: 1rem;
-}
-
 .text-left {
   text-align: left;
 }
@@ -1356,14 +1342,14 @@ video {
   line-height: 1.25rem;
 }
 
-.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
-}
-
 .text-sm\/6 {
   font-size: 0.875rem;
   line-height: 1.5rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
 }
 
 .font-bold {
@@ -1475,6 +1461,11 @@ video {
   color: rgb(248 113 113 / var(--tw-text-opacity));
 }
 
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
+
 .text-teal-400 {
   --tw-text-opacity: 1;
   color: rgb(45 212 191 / var(--tw-text-opacity));
@@ -1490,19 +1481,9 @@ video {
   color: rgb(15 118 110 / var(--tw-text-opacity));
 }
 
-.text-green-600 {
-  --tw-text-opacity: 1;
-  color: rgb(22 163 74 / var(--tw-text-opacity));
-}
-
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.text-red-600 {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
 }
 
 .underline {
@@ -1573,15 +1554,6 @@ video {
   --tw-ring-color: rgb(0 0 0 / var(--tw-ring-opacity));
 }
 
-.ring-green-600\/20 {
-  --tw-ring-color: rgb(22 163 74 / 0.2);
-}
-
-.ring-teal-600 {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
-}
-
 .ring-gray-300 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(209 213 219 / var(--tw-ring-opacity));
@@ -1590,6 +1562,15 @@ video {
 .ring-gray-700 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(55 65 81 / var(--tw-ring-opacity));
+}
+
+.ring-green-600\/20 {
+  --tw-ring-color: rgb(22 163 74 / 0.2);
+}
+
+.ring-teal-600 {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
 }
 
 .ring-opacity-5 {
@@ -1649,12 +1630,12 @@ video {
   transition-duration: 200ms;
 }
 
-.duration-75 {
-  transition-duration: 75ms;
-}
-
 .duration-300 {
   transition-duration: 300ms;
+}
+
+.duration-75 {
+  transition-duration: 75ms;
 }
 
 .ease-in {
@@ -1735,11 +1716,6 @@ video {
   background-color: rgb(20 184 166 / var(--tw-bg-opacity));
 }
 
-.hover\:bg-red-500:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
-}
-
 .hover\:font-bold:hover {
   font-weight: 700;
 }
@@ -1782,11 +1758,6 @@ video {
 .focus\:ring-indigo-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
-}
-
-.focus\:ring-indigo-600:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(79 70 229 / var(--tw-ring-opacity));
 }
 
 .focus\:ring-teal-600:focus {
@@ -1836,18 +1807,30 @@ video {
     margin-bottom: -1px;
   }
 
-  .sm\:my-8 {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-  }
-
   .sm\:mx-0 {
     margin-left: 0px;
     margin-right: 0px;
   }
 
+  .sm\:my-8 {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .sm\:ml-4 {
+    margin-left: 1rem;
+  }
+
   .sm\:ml-6 {
     margin-left: 1.5rem;
+  }
+
+  .sm\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .sm\:mt-4 {
+    margin-top: 1rem;
   }
 
   .sm\:mt-5 {
@@ -1856,22 +1839,6 @@ video {
 
   .sm\:mt-6 {
     margin-top: 1.5rem;
-  }
-
-  .sm\:mt-0 {
-    margin-top: 0px;
-  }
-
-  .sm\:ml-3 {
-    margin-left: 0.75rem;
-  }
-
-  .sm\:ml-4 {
-    margin-left: 1rem;
-  }
-
-  .sm\:mt-4 {
-    margin-top: 1rem;
   }
 
   .sm\:flex {
@@ -1891,12 +1858,16 @@ video {
     height: 2.5rem;
   }
 
+  .sm\:w-auto {
+    width: auto;
+  }
+
   .sm\:w-full {
     width: 100%;
   }
 
-  .sm\:w-auto {
-    width: auto;
+  .sm\:max-w-lg {
+    max-width: 32rem;
   }
 
   .sm\:max-w-sm {
@@ -1905,10 +1876,6 @@ video {
 
   .sm\:max-w-xs {
     max-width: 20rem;
-  }
-
-  .sm\:max-w-lg {
-    max-width: 32rem;
   }
 
   .sm\:translate-y-0 {
@@ -1960,12 +1927,12 @@ video {
     align-items: center;
   }
 
-  .sm\:gap-px {
-    gap: 1px;
-  }
-
   .sm\:gap-3 {
     gap: 0.75rem;
+  }
+
+  .sm\:gap-px {
+    gap: 1px;
   }
 
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1984,12 +1951,12 @@ video {
     border-top-right-radius: 0px;
   }
 
-  .sm\:p-6 {
-    padding: 1.5rem;
-  }
-
   .sm\:p-0 {
     padding: 0px;
+  }
+
+  .sm\:p-6 {
+    padding: 1.5rem;
   }
 
   .sm\:px-4 {

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -874,6 +874,18 @@ video {
   width: 100vw;
 }
 
+.w-1\/4 {
+  width: 25%;
+}
+
+.w-1\/3 {
+  width: 33.333333%;
+}
+
+.w-2\/3 {
+  width: 66.666667%;
+}
+
 .max-w-7xl {
   max-width: 80rem;
 }
@@ -1124,6 +1136,11 @@ video {
 
 .bg-gray-500\/75 {
   background-color: rgb(107 114 128 / 0.75);
+}
+
+.bg-green-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
 }
 
 .bg-green-50 {
@@ -1441,6 +1458,11 @@ video {
   color: rgb(74 222 128 / var(--tw-text-opacity));
 }
 
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity));
+}
+
 .text-green-700 {
   --tw-text-opacity: 1;
   color: rgb(21 128 61 / var(--tw-text-opacity));
@@ -1492,6 +1514,10 @@ video {
 
 .decoration-2 {
   text-decoration-thickness: 2px;
+}
+
+.decoration-1 {
+  text-decoration-thickness: 1px;
 }
 
 .underline-offset-4 {
@@ -1571,6 +1597,11 @@ video {
 .ring-teal-600 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(13 148 136 / var(--tw-ring-opacity));
+}
+
+.ring-gray-500 {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(107 114 128 / var(--tw-ring-opacity));
 }
 
 .ring-opacity-5 {

--- a/src/lsst/cmservice/web_app/static/css/output.css
+++ b/src/lsst/cmservice/web_app/static/css/output.css
@@ -894,6 +894,10 @@ video {
   flex-shrink: 0;
 }
 
+.shrink-0 {
+  flex-shrink: 0;
+}
+
 .flex-grow {
   flex-grow: 1;
 }
@@ -1184,6 +1188,11 @@ video {
 .bg-indigo-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(79 70 229 / var(--tw-bg-opacity));
+}
+
+.bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
 }
 
 .p-1 {
@@ -1491,6 +1500,11 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
+
 .underline {
   text-decoration-line: underline;
 }
@@ -1721,6 +1735,11 @@ video {
   background-color: rgb(20 184 166 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-red-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+}
+
 .hover\:font-bold:hover {
   font-weight: 700;
 }
@@ -1822,6 +1841,11 @@ video {
     margin-bottom: 2rem;
   }
 
+  .sm\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
   .sm\:ml-6 {
     margin-left: 1.5rem;
   }
@@ -1838,6 +1862,18 @@ video {
     margin-top: 0px;
   }
 
+  .sm\:ml-3 {
+    margin-left: 0.75rem;
+  }
+
+  .sm\:ml-4 {
+    margin-left: 1rem;
+  }
+
+  .sm\:mt-4 {
+    margin-top: 1rem;
+  }
+
   .sm\:flex {
     display: flex;
   }
@@ -1850,8 +1886,17 @@ video {
     display: none;
   }
 
+  .sm\:size-10 {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
   .sm\:w-full {
     width: 100%;
+  }
+
+  .sm\:w-auto {
+    width: auto;
   }
 
   .sm\:max-w-sm {
@@ -1860,6 +1905,10 @@ video {
 
   .sm\:max-w-xs {
     max-width: 20rem;
+  }
+
+  .sm\:max-w-lg {
+    max-width: 32rem;
   }
 
   .sm\:translate-y-0 {
@@ -1897,6 +1946,14 @@ video {
 
   .sm\:grid-cols-6 {
     grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .sm\:flex-row-reverse {
+    flex-direction: row-reverse;
+  }
+
+  .sm\:items-start {
+    align-items: flex-start;
   }
 
   .sm\:items-center {
@@ -1943,6 +2000,10 @@ video {
   .sm\:px-6 {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
+  }
+
+  .sm\:text-left {
+    text-align: left;
   }
 
   .sm\:text-sm {

--- a/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
+++ b/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
@@ -149,7 +149,7 @@ class ResetButtonCellRenderer {
              statusDropdown.options.length = 0;
              let currentStatus = params.data.status;
              if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
-                 document.querySelector('#modal-title').innerText = "Reset Script";
+                 document.querySelector('#reset-modal-title').innerText = "Reset Script";
                  Object.keys(resetFromRejected).forEach(state => {
                      let option = document.createElement('option');
                      option.setAttribute('value', resetFromRejected[state]);
@@ -157,7 +157,7 @@ class ResetButtonCellRenderer {
                      statusDropdown.add(option);
                  });
              } else if (currentStatus === "REVIEWABLE") {
-                 document.querySelector('#modal-title').innerText = "Review Script";
+                 document.querySelector('#reset-modal-title').innerText = "Review Script";
                  Object.keys(resetFromReviewable).forEach(state => {
                      let option = document.createElement('option');
                      option.setAttribute('value', resetFromReviewable[state]);

--- a/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
+++ b/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
@@ -10,7 +10,7 @@ const resetFromReviewable = {
     REJECTED: -3,
 };
 
-const updateStatus = () => {
+const updateStatus = async () => {
     const rowIndex = parseInt(document.querySelector("#rowIndex").innerText);
     const newStatus = parseInt(document.querySelector("#targetStatus").value);
     const fullname = String(document.querySelector("#scriptFullname").innerText)
@@ -39,132 +39,124 @@ const updateStatus = () => {
     }
 
     // send request
-    let xhr = new XMLHttpRequest();
-    xhr.open('POST', url, true);
-    xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-    xhr.onload = function () {
-        if (xhr.status === 201) {
-            // update script status in grid
-            scriptGridApi
-                .getRowNode(rowIndex)
-                .setDataValue("status", document.querySelector("#targetStatus").selectedOptions[0].text);
-            // refresh grid cells on client side to disable/enable reset button according to new status
-            scriptGridApi.refreshCells({
-                force: true,
-                suppressFlash: false,
-              });
-            resetScriptModal.close();
-        } else {
-            resetScriptModal.close();
-            errorModal.showModal();
-            errorMessage.innerText = JSON.parse(xhr.responseText).detail;
+    const response = await fetch(url, {
+        method: "POST",
+        body: resetJson,
+        headers: {
+            "Content-Type": "application/json"
         }
-    };
-    xhr.onerror = function () {
+    });
+
+    if(response.ok) {
+        // update script status in grid
+        scriptGridApi
+            .getRowNode(rowIndex)
+            .setDataValue("status", document.querySelector("#targetStatus").selectedOptions[0].text);
+        // refresh grid cells on client side to disable/enable reset button according to new status
+        scriptGridApi.refreshCells({
+            force: true,
+            suppressFlash: false,
+          });
+        resetScriptModal.close();
+    } else {
         resetScriptModal.close();
         errorModal.showModal();
-        errorMessage.innerText = xhr.responseText;
-    };
-    xhr.send(resetJson);
-
+        errorMessage.innerText = JSON.parse(await response.text()).detail;
+    }
 };
 
-const readScriptLog = (log_url) => {
-
-    const xhr = new XMLHttpRequest();
-
+const readScriptLog = async (logURL) => {
     const url = "/web_app/read-script-log";
-
-    xhr.onreadystatechange = function () {
-        if (xhr.readyState === XMLHttpRequest.DONE) {
-            if (xhr.status === 200) {
-                const response = JSON.parse(xhr.responseText);
-                // show file content from response in the textarea
-                document.querySelector('#scriptLogContent').value = response.content;
-                scriptLogModal.showModal();
-            } else {
-                errorModal.showModal();
-                errorMessage.innerText = JSON.parse(xhr.responseText).detail;
-            }
+    const res  = await fetch(url, {
+        method: "POST",
+        body: JSON.stringify({ log_path: logURL}),
+        headers: {
+            "Content-Type": "application/json"
         }
-    };
+    });
+    if(!res.ok) {
+        errorModal.showModal();
+        errorMessage.innerText = JSON.parse(await res.text()).detail;
+    } else {
+        let response = await res.json()
+        document.querySelector('#scriptLogContent').value = response.content;
+        scriptLogModal.showModal();
+    }
+};
 
-    xhr.open("POST", url, true);
-
-    xhr.setRequestHeader("Content-Type", "application/json");
-
-    const requestData = JSON.stringify({ log_path: log_url});
-    xhr.send(requestData);
-}
+const fillTargetStatusDropdown = (statusEnum) => {
+    let statusDropdown = document.querySelector("#targetStatus");
+    statusDropdown.options.length = 0;
+    Object.keys(statusEnum).forEach(state => {
+        let option = document.createElement('option');
+        option.setAttribute('value', statusEnum[state]);
+        option.innerText = state;
+        statusDropdown.add(option);
+    });
+};
 
 class ResetButtonCellRenderer {
     init(params) {
         this.params = params;
-        this.eGui = document.createElement('button');
-        // change button text and also enable/disable according to status
-        let currentStatus = params.data.status;
-        if(currentStatus === "FAILED" || currentStatus === "REJECTED") {
-            this.eGui.innerText = 'Reset';
-        } else if(currentStatus === "REVIEWABLE") {
-            this.eGui.innerText = 'Review';
+        this.eGui = document.createElement('div');
+
+        let gridShowLogBtn = document.createElement('button');
+        gridShowLogBtn.innerText = "Show Log";
+        if(params.data.log_url){
+            gridShowLogBtn.setAttribute("class", 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+            gridShowLogBtn.addEventListener('click', async () => await readScriptLog(params.data.log_url));
+            gridShowLogBtn.disabled = false;
         } else {
-            // button is disabled if the current status isn't FAILED/REJECTED/REVIEWABLE
-            this.eGui.innerText = 'Reset';
-            this.eGui.disabled = true;
-            this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+            gridShowLogBtn.setAttribute("class", 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+            gridShowLogBtn.disabled = true;
+        }
+        this.eGui.appendChild(gridShowLogBtn);
+
+        let resetBtn = document.createElement('button');
+        // change button text and also show/hide according to status
+        let currentStatus = params.data.status;
+        this.eGui.appendChild(resetBtn);
+
+        if(currentStatus === "FAILED" || currentStatus === "REJECTED") {
+            resetBtn.innerText = 'Reset';
+        } else if(currentStatus === "REVIEWABLE") {
+            resetBtn.innerText = 'Review';
+        } else {
+            // button is hidden if the current status isn't FAILED/REJECTED/REVIEWABLE
+            resetBtn.hidden = true;
             return;
         }
-        // enable reset/review button
-        this.eGui.disabled = false;
-        this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+        // show reset/review button
+        resetBtn.hidden = false;
+        resetBtn.setAttribute('class', 'ml-2 mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
 
-        this.eGui.addEventListener('click', () => {
+        resetBtn.addEventListener('click', () => {
             document.querySelector("#rowIndex").innerText = params.node.rowIndex;
              document.querySelector("#scriptFullname").innerText = params.data.fullname;
 
-             // show script log path if it isn't null, otherwise show "-"
+             // show script log path and button if it isn't null, otherwise show "-" and hide button
              const scriptLogElement = document.querySelector("#scriptLogUrl");
-             scriptLogElement.innerHTML = "";
              if(params.data.log_url) {
-                 let logUrl = document.createElement('span');
-                 logUrl.innerText = params.data.log_url;
-                 scriptLogElement.appendChild(logUrl);
-
-                 // add a button to show log content dialog
-                 let showLogBtn = document.createElement('button');
-                 showLogBtn.innerText = 'Show Log';
-                 showLogBtn.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
-                 showLogBtn.addEventListener('click', (e) => {
-                     readScriptLog(params.data.log_url);
-                 });
-                 scriptLogElement.appendChild(showLogBtn);
-
+                 scriptLogElement.innerText = params.data.log_url;
+                 showLogBtn.hidden = false;
              } else {
                  scriptLogElement.innerText = "-";
+                 showLogBtn.hidden = true;
              }
+             showLogBtn.addEventListener("click", async() => await readScriptLog(params.data.log_url));
+
              // create target status dropdown according to current status
-             let statusDropdown = document.querySelector("#targetStatus");
-             statusDropdown.options.length = 0;
              let currentStatus = params.data.status;
              if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
                  document.querySelector('#reset-modal-title').innerText = "Reset Script";
-                 Object.keys(resetFromRejected).forEach(state => {
-                     let option = document.createElement('option');
-                     option.setAttribute('value', resetFromRejected[state]);
-                     option.innerText = state;
-                     statusDropdown.add(option);
-                 });
+                 fillTargetStatusDropdown(resetFromRejected);
              } else if (currentStatus === "REVIEWABLE") {
                  document.querySelector('#reset-modal-title').innerText = "Review Script";
-                 Object.keys(resetFromReviewable).forEach(state => {
-                     let option = document.createElement('option');
-                     option.setAttribute('value', resetFromReviewable[state]);
-                     option.innerText = state;
-                     statusDropdown.add(option);
-                 });
+                 fillTargetStatusDropdown(resetFromReviewable);
              }
              resetScriptModal.showModal();
         });
+
     }
 
     getGui() {
@@ -174,11 +166,14 @@ class ResetButtonCellRenderer {
 
 
 const resetScriptModal = document.querySelector("#modalDialog");
+
 const closeResetModalBtn = document.querySelector("[close-reset-modal]");
 closeResetModalBtn.addEventListener("click", () => resetScriptModal.close());
 
 const confirmResetBtn = document.querySelector("[confirm-reset]");
 confirmResetBtn.addEventListener("click", updateStatus);
+
+const showLogBtn = document.querySelector("#showLogBtn");
 
 const errorModal = document.querySelector("#errorModal");
 const closeErrModalBtn = document.querySelector("[close-error-modal]");

--- a/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
+++ b/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
@@ -11,36 +11,60 @@ const resetFromReviewable = {
 };
 
 const updateStatus = () => {
-    let resetObj = {
-        fullname: String(document.querySelector("#scriptFullname").innerText),
-        status: parseInt(document.querySelector("#targetStatus").value),
-    };
+    const rowIndex = parseInt(document.querySelector("#rowIndex").innerText);
+    const newStatus = parseInt(document.querySelector("#targetStatus").value);
+    const fullname = String(document.querySelector("#scriptFullname").innerText)
+    const scriptId = scriptGridApi.getRowNode(rowIndex).data.id;
 
-    let resetJson = JSON.stringify(resetObj);
+    let url;
+    let resetJson = null;
 
+    // accept script
+    if(newStatus === 5){
+        url = `/cm-service/v1/script/action/${scriptId}/accept`;
+    }
+    // reject script
+    else if(newStatus === -3){
+        url = `/cm-service/v1/script/action/${scriptId}/reject`;
+    }
+    // reset script
+    else {
+        let resetObj = {
+            fullname: fullname,
+            status: newStatus,
+        };
+
+        resetJson = JSON.stringify(resetObj);
+        url = reset_script_endpoint;
+    }
+
+    // send request
     let xhr = new XMLHttpRequest();
-    xhr.open('POST', reset_script_endpoint, true);
+    xhr.open('POST', url, true);
     xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
     xhr.onload = function () {
         console.log(xhr.responseText);
 
         if (xhr.status === 201) {
-            const rowIndex = Number(document.querySelector("#rowIndex").innerText);
-            const newStatus = resetObj.status;
-            scriptGridApi.getRowNode(rowIndex).setDataValue("status", newStatus);
+            scriptGridApi.getRowNode(rowIndex).setDataValue("status", document.querySelector("#targetStatus").selectedOptions[0].text);
+            scriptGridApi.refreshCells({
+                force: true,
+                suppressFlash: false,
+              });
             resetScriptModal.close();
         } else {
             resetScriptModal.close();
             errorModal.showModal();
-            errorMessage.innerText = 'Error resetting script!';
+            errorMessage.innerText = 'Error accepting script!';
         }
     };
     xhr.onerror = function () {
         console.error("Request failed");
-        alert('Error resetting script!');
+        alert('Error accepting script!');
         resetScriptModal.close();
     };
     xhr.send(resetJson);
+
 };
 
 class ResetButtonCellRenderer {
@@ -48,38 +72,61 @@ class ResetButtonCellRenderer {
         this.params = params;
         this.eGui = document.createElement('button');
         this.eGui.innerText = 'Reset';
+        let currentStatus = params.data.status;
+
+        if(currentStatus === "FAILED" || currentStatus === "REJECTED") {
+            this.eGui.innerText = 'Reset';
+        } else if(currentStatus === "REVIEWABLE") {
+            this.eGui.innerText = 'Review';
+        } else {
+            this.eGui.disabled = true;
+            this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+            return;
+        }
+
+        this.eGui.disabled = false;
         this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
 
         this.eGui.addEventListener('click', () => {
+            document.querySelector("#rowIndex").innerText = params.node.rowIndex;
+             document.querySelector("#scriptFullname").innerText = params.data.fullname;
+             const scriptLogElement = document.querySelector("#scriptLogUrl");
+             scriptLogElement.innerHTML = "";
+             if(params.data.log_url) {
+                 let logUrlHref = document.createElement('a');
+                 logUrlHref.setAttribute('class', 'text-teal-700 underline underline-offset-4 decoration-1 hover:text-gray-500');
+                 logUrlHref.href = params.data.log_url;
+                 logUrlHref.innerText = params.data.log_url;
+                 scriptLogElement.appendChild(logUrlHref);
+             } else {
+                 scriptLogElement.innerText = "-";
+             }
 
-         document.querySelector("#rowIndex").innerText = params.node.rowIndex;
-         document.querySelector("#scriptFullname").innerText = params.data.fullname;
-
-         let statusDropdown = document.querySelector("#targetStatus");
-         statusDropdown.options.length = 0;
-
-         let currentStatus = params.data.status;
-
-         if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
-             Object.keys(resetFromRejected).forEach(state => {
-                 let option = document.createElement('option');
-                 option.setAttribute('value', resetFromRejected[state]);
-                 option.innerText = state;
-                 statusDropdown.add(option);
-             });
-         } else if (currentStatus === "REVIEWABLE") {
-             Object.keys(resetFromReviewable).forEach(state => {
-                 let option = document.createElement('option');
-                 option.setAttribute('value', resetFromReviewable[state]);
-                 option.innerText = state;
-                 statusDropdown.add(option);
-             });
-         } else {
-             errorModal.showModal();
-             errorMessage.innerText = `Cannot reset a script from ${currentStatus} status`;
-             return;
-         }
-         resetScriptModal.showModal();
+             let statusDropdown = document.querySelector("#targetStatus");
+             statusDropdown.options.length = 0;
+             let currentStatus = params.data.status;
+             if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
+                 document.querySelector('#modal-title').innerText = "Reset Script";
+                 Object.keys(resetFromRejected).forEach(state => {
+                     let option = document.createElement('option');
+                     option.setAttribute('value', resetFromRejected[state]);
+                     option.innerText = state;
+                     statusDropdown.add(option);
+                 });
+             } else if (currentStatus === "REVIEWABLE") {
+                 document.querySelector('#modal-title').innerText = "Review Script";
+                 Object.keys(resetFromReviewable).forEach(state => {
+                     let option = document.createElement('option');
+                     option.setAttribute('value', resetFromReviewable[state]);
+                     option.innerText = state;
+                     statusDropdown.add(option);
+                 });
+             } else {
+                 errorModal.showModal();
+                 errorMessage.innerText = `Cannot reset a script from ${currentStatus} status`;
+                 return;
+             }
+             resetScriptModal.showModal();
         });
     }
 

--- a/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
+++ b/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
@@ -1,0 +1,102 @@
+// list of statuses to reset to if current status is failed or rejected
+const resetFromRejected = {
+    WAITING: 0,
+    READY: 1,
+    PREPARED: 2
+};
+// list of statuses to reset to if current status is reviewable
+const resetFromReviewable = {
+    ACCEPTED: 5,
+    REJECTED: -3,
+};
+
+const updateStatus = () => {
+    let resetObj = {
+        fullname: String(document.querySelector("#scriptFullname").innerText),
+        status: parseInt(document.querySelector("#targetStatus").value),
+    };
+
+    let resetJson = JSON.stringify(resetObj);
+
+    let xhr = new XMLHttpRequest();
+    xhr.open('POST', reset_script_endpoint, true);
+    xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+    xhr.onload = function () {
+        console.log(xhr.responseText);
+
+        if (xhr.status === 201) {
+            const rowIndex = Number(document.querySelector("#rowIndex").innerText);
+            const newStatus = resetObj.status;
+            scriptGridApi.getRowNode(rowIndex).setDataValue("status", newStatus);
+            resetScriptModal.close();
+        } else {
+            resetScriptModal.close();
+            errorModal.showModal();
+            errorMessage.innerText = 'Error resetting script!';
+        }
+    };
+    xhr.onerror = function () {
+        console.error("Request failed");
+        alert('Error resetting script!');
+        resetScriptModal.close();
+    };
+    xhr.send(resetJson);
+};
+
+class ResetButtonCellRenderer {
+    init(params) {
+        this.params = params;
+        this.eGui = document.createElement('button');
+        this.eGui.innerText = 'Reset';
+        this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+
+        this.eGui.addEventListener('click', () => {
+
+         document.querySelector("#rowIndex").innerText = params.node.rowIndex;
+         document.querySelector("#scriptFullname").innerText = params.data.fullname;
+
+         let statusDropdown = document.querySelector("#targetStatus");
+         statusDropdown.options.length = 0;
+
+         let currentStatus = params.data.status;
+
+         if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
+             Object.keys(resetFromRejected).forEach(state => {
+                 let option = document.createElement('option');
+                 option.setAttribute('value', resetFromRejected[state]);
+                 option.innerText = state;
+                 statusDropdown.add(option);
+             });
+         } else if (currentStatus === "REVIEWABLE") {
+             Object.keys(resetFromReviewable).forEach(state => {
+                 let option = document.createElement('option');
+                 option.setAttribute('value', resetFromReviewable[state]);
+                 option.innerText = state;
+                 statusDropdown.add(option);
+             });
+         } else {
+             errorModal.showModal();
+             errorMessage.innerText = `Cannot reset a script from ${currentStatus} status`;
+             return;
+         }
+         resetScriptModal.showModal();
+        });
+    }
+
+    getGui() {
+        return this.eGui;
+  }
+}
+
+
+const resetScriptModal = document.querySelector("#modalDialog");
+const closeResetModalBtn = document.querySelector("[close-reset-modal]");
+closeResetModalBtn.addEventListener("click", () => resetScriptModal.close());
+
+const confirmResetBtn = document.querySelector("[confirm-reset]");
+confirmResetBtn.addEventListener("click", updateStatus);
+
+const errorModal = document.querySelector("#errorModal");
+const closeErrModalBtn = document.querySelector("[close-error-modal]");
+closeErrModalBtn.addEventListener("click", () => errorModal.close());
+const errorMessage = document.querySelector("[error-message]")

--- a/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
+++ b/src/lsst/cmservice/web_app/static/js/script-grid-utils.js
@@ -20,11 +20,11 @@ const updateStatus = () => {
     let resetJson = null;
 
     // accept script
-    if(newStatus === 5){
+    if(newStatus === resetFromReviewable.ACCEPTED){
         url = `/cm-service/v1/script/action/${scriptId}/accept`;
     }
     // reject script
-    else if(newStatus === -3){
+    else if(newStatus === resetFromReviewable.REJECTED){
         url = `/cm-service/v1/script/action/${scriptId}/reject`;
     }
     // reset script
@@ -61,7 +61,6 @@ const updateStatus = () => {
         }
     };
     xhr.onerror = function () {
-        console.error("Error:", xhr.status, xhr.responseText);
         resetScriptModal.close();
         errorModal.showModal();
         errorMessage.innerText = xhr.responseText;
@@ -84,7 +83,6 @@ const readScriptLog = (log_url) => {
                 document.querySelector('#scriptLogContent').value = response.content;
                 scriptLogModal.showModal();
             } else {
-                console.error("Error:", xhr.status, xhr.responseText);
                 errorModal.showModal();
                 errorMessage.innerText = JSON.parse(xhr.responseText).detail;
             }
@@ -95,7 +93,7 @@ const readScriptLog = (log_url) => {
 
     xhr.setRequestHeader("Content-Type", "application/json");
 
-    const requestData = JSON.stringify({ log_path: log_url});//'/home/eman/PycharmProjects/cm-service/output/archive/HSC_DRP-Prod/test_htcondor/step1/group1/job_000/bps_submit_000_bps_config.yaml' });
+    const requestData = JSON.stringify({ log_path: log_url});
     xhr.send(requestData);
 }
 

--- a/src/lsst/cmservice/web_app/templates/pages/group_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/group_details.html
@@ -3,6 +3,8 @@
 {% block content %}
 {% include "partials/reset_script_modal.html" %}
 {% include "partials/error_modal.html" %}
+{% include "partials/script_log_modal.html" %}
+
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";

--- a/src/lsst/cmservice/web_app/templates/pages/group_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/group_details.html
@@ -1,7 +1,11 @@
 {% extends "pages/base.html" %}
 {% block title %} Group Details {% endblock %}
 {% block content %}
+{% include "partials/reset_script_modal.html" %}
+{% include "partials/error_modal.html" %}
+<script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    const reset_script_endpoint = "{{url_for('reset_script')}}";
     class JobNameRenderer {
         eGui;
 
@@ -44,16 +48,21 @@
     }
 
     const scriptsGridOptions = {
-        // rowData: scriptsJson,
         columnDefs: [
             {field: "name", flex: 1, cellRenderer: ScriptNameRenderer,},
             {field: "status", flex: 1},
-            {field: "superseded", flex: 1}
+            {field: "superseded", flex: 1},
+            {
+                headerName: 'Actions',
+                field: 'resetButton',
+                cellRenderer: ResetButtonCellRenderer,
+                editable: false,
+                width: 200,
+            },
         ]
     };
 
     const jobsGridOptions = {
-        // rowData: jobsJson,
         columnDefs: [
             {field: "name", flex: 1, cellRenderer: JobNameRenderer},
             {field: "status", flex: 1},
@@ -65,7 +74,6 @@
     };
     const formatWMSColumn = (params) => params.value === 0 ? "" : params.value;
     const wmsReportOptions = {
-        // rowData: wmsReportJson,
         defaultColDef: {
             resizable: false,
             width: 100,

--- a/src/lsst/cmservice/web_app/templates/pages/group_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/group_details.html
@@ -94,10 +94,12 @@
             {field: "n_pruned", headerName: "Pruned", valueFormatter: formatWMSColumn},
         ]
     };
+
+    let scriptGridApi;
     const populateScriptsGrid = (scriptsJson) => {
         scriptsGridOptions.rowData = scriptsJson;
         const scriptsGridElement = document.getElementById("scriptsGrid");
-        agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
+        scriptGridApi = agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
     };
 
     // jobs
@@ -114,14 +116,12 @@
         agGrid.createGrid(wmsReportGridElement, wmsReportOptions);
     };
 
+    let groupScripts;
+    let groupJobs;
+    let wmsReport;
     const populateGrids = () => {
-        const groupScripts = {{scripts|tojson}};
         populateScriptsGrid(groupScripts);
-
-        const groupJobs = {{jobs|tojson}};
         populateJobsGrid(groupJobs);
-
-        const wmsReport = {{group.wms_report|tojson}};
         populateWMSReportGrid(wmsReport);
     };
 
@@ -163,6 +163,11 @@
 <div class="w-full" id="group_content"
      hx-get="{{ url_for('get_group', campaign_id=group.campaign_id, step_id=group.step_id, group_id=group.id) }}"
      hx-trigger="every 20s" hx-select="#group_content" hx-swap="outerHTML">
+    <script>
+        groupScripts = {{scripts|sort(attribute="id")|tojson}};
+        groupJobs = {{jobs|sort(attribute="id")|tojson}};
+        wmsReport = {{group.wms_report|tojson}};
+    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="flex items-center">
             <span class="text-2xl font-bold">{{group.name}}</span>

--- a/src/lsst/cmservice/web_app/templates/pages/group_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/group_details.html
@@ -7,6 +7,18 @@
 
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    let groupScripts;
+    let groupJobs;
+    let wmsReport;
+</script>
+<script hx-swap-oob="outerHTML:#grid_data" id="grid_data">
+    // Update data objects with every htmx reload
+    // to reflect any db changes
+    groupScripts = {{scripts|sort(attribute="id")|tojson}};
+    groupJobs = {{jobs|sort(attribute="id")|tojson}};
+    wmsReport = {{group.wms_report|tojson}};
+</script>
+<script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";
     class JobNameRenderer {
         eGui;
@@ -118,9 +130,6 @@
         agGrid.createGrid(wmsReportGridElement, wmsReportOptions);
     };
 
-    let groupScripts;
-    let groupJobs;
-    let wmsReport;
     const populateGrids = () => {
         populateScriptsGrid(groupScripts);
         populateJobsGrid(groupJobs);
@@ -165,11 +174,6 @@
 <div class="w-full" id="group_content"
      hx-get="{{ url_for('get_group', campaign_id=group.campaign_id, step_id=group.step_id, group_id=group.id) }}"
      hx-trigger="every 20s" hx-select="#group_content" hx-swap="outerHTML">
-    <script>
-        groupScripts = {{scripts|sort(attribute="id")|tojson}};
-        groupJobs = {{jobs|sort(attribute="id")|tojson}};
-        wmsReport = {{group.wms_report|tojson}};
-    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="flex items-center">
             <span class="text-2xl font-bold">{{group.name}}</span>

--- a/src/lsst/cmservice/web_app/templates/pages/job_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/job_details.html
@@ -41,10 +41,11 @@
             },
         ]
     };
+    let scriptGridApi;
     const populateScriptsGrid = (scriptsJson) => {
         scriptsGridOptions.rowData = scriptsJson;
         const scriptsGridElement = document.getElementById("scriptsGrid");
-        agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
+        scriptGridApi = agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
     }
 
     // products
@@ -96,14 +97,12 @@
         agGrid.createGrid(wmsReportGridElement, wmsReportOptions);
     };
 
+    let jobScripts;
+    let jobProducts;
+    let wmsReport;
     const populateGrids = () => {
-        const jobScripts = {{scripts|tojson}};
         populateScriptsGrid(jobScripts);
-
-        const jobProducts = {{job.products|tojson}};
         populateProductsGrid(jobProducts);
-
-        const wmsReport = {{job.wms_report|tojson}};
         populateWMSReportGrid(wmsReport);
     };
 
@@ -157,6 +156,12 @@
      hx-trigger="every 20s"
      hx-select="#job_content"
      hx-swap="outerHTML">
+    <script>
+        // moved here to make sure data is refreshed with every htmx request
+        jobScripts = {{scripts|sort(attribute="id")|tojson}};
+        jobProducts = {{job.products|tojson}};
+        wmsReport = {{job.wms_report|tojson}};
+    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="flex items-center">
             <span class="text-2xl font-bold">{{job.name}}</span>

--- a/src/lsst/cmservice/web_app/templates/pages/job_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/job_details.html
@@ -10,7 +10,7 @@
     let jobProducts;
     let wmsReport;
 </script>
-<script hx-swap-oob="outerHTML:#grid_handling" id="grid_handling">
+<script hx-swap-oob="outerHTML:#grid_data" id="grid_data">
     // Update data objects with every htmx reload
     // to reflect any db changes
     jobScripts = {{scripts|sort(attribute="id")|tojson}};

--- a/src/lsst/cmservice/web_app/templates/pages/job_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/job_details.html
@@ -6,6 +6,18 @@
 {% include "partials/script_log_modal.html" %}
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    let jobScripts;
+    let jobProducts;
+    let wmsReport;
+</script>
+<script hx-swap-oob="outerHTML:#grid_handling" id="grid_handling">
+    // Update data objects with every htmx reload
+    // to reflect any db changes
+    jobScripts = {{scripts|sort(attribute="id")|tojson}};
+    jobProducts = {{job.products|tojson}};
+    wmsReport = {{job.wms_report|tojson}};
+</script>
+<script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";
     class ScriptNameRenderer {
         eGui;
@@ -97,10 +109,6 @@
         const wmsReportGridElement = document.getElementById("wmsReportGrid");
         agGrid.createGrid(wmsReportGridElement, wmsReportOptions);
     };
-
-    let jobScripts;
-    let jobProducts;
-    let wmsReport;
     const populateGrids = () => {
         populateScriptsGrid(jobScripts);
         populateProductsGrid(jobProducts);
@@ -157,12 +165,6 @@
      hx-trigger="every 20s"
      hx-select="#job_content"
      hx-swap="outerHTML">
-    <script>
-        // moved here to make sure data is refreshed with every htmx request
-        jobScripts = {{scripts|sort(attribute="id")|tojson}};
-        jobProducts = {{job.products|tojson}};
-        wmsReport = {{job.wms_report|tojson}};
-    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="flex items-center">
             <span class="text-2xl font-bold">{{job.name}}</span>

--- a/src/lsst/cmservice/web_app/templates/pages/job_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/job_details.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% include "partials/reset_script_modal.html" %}
 {% include "partials/error_modal.html" %}
+{% include "partials/script_log_modal.html" %}
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";

--- a/src/lsst/cmservice/web_app/templates/pages/job_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/job_details.html
@@ -1,7 +1,11 @@
 {% extends "pages/base.html" %}
 {% block title %} Job Details {% endblock %}
 {% block content %}
+{% include "partials/reset_script_modal.html" %}
+{% include "partials/error_modal.html" %}
+<script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    const reset_script_endpoint = "{{url_for('reset_script')}}";
     class ScriptNameRenderer {
         eGui;
 
@@ -24,11 +28,17 @@
     }
 
     const scriptsGridOptions = {
-        // rowData: jobScripts,
         columnDefs: [
-             {field: "name", flex: 1, cellRenderer: ScriptNameRenderer,},
-             {field: "status", flex: 1},
-             {field: "superseded", flex: 1}
+            {field: "name", flex: 1, cellRenderer: ScriptNameRenderer,},
+            {field: "status", flex: 1},
+            {field: "superseded", flex: 1},
+            {
+                headerName: 'Actions',
+                field: 'resetButton',
+                cellRenderer: ResetButtonCellRenderer,
+                editable: false,
+                width: 200,
+            },
         ]
     };
     const populateScriptsGrid = (scriptsJson) => {
@@ -41,7 +51,6 @@
     const formatWMSColumn = (params) => params.value === 0 ? "" : params.value;
 
     const productsGridOptions = {
-        // rowData: jobProducts,
         columnDefs: [
             {field: "name", headerName: "Name", flex: 2,},
             {field: "n_expected", headerName: "Expected", valueFormatter: formatWMSColumn},
@@ -61,7 +70,6 @@
     // WMS task report
 
     const wmsReportOptions = {
-        // rowData: wmsReport,
         defaultColDef: {
             resizable: false,
             width: 100,

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -1,6 +1,7 @@
 {% extends "pages/base.html" %}
 {% block title %} Step Details {% endblock %}
 {% block content %}
+{% include "partials/reset_script_modal.html" %}
 <script>
     class GroupNameRenderer {
         eGui;
@@ -70,16 +71,133 @@
      }
     }
 
+    // list of statuses to reset to if current status is failed or rejected
+    const resetFromRejected = {
+        WAITING: 0,
+        READY: 1,
+        PREPARED: 2
+    };
+
+    const resetFromReviewable = {
+        ACCEPTED: 5,
+        REJECTED: -3,
+    };
+    class ButtonCellRenderer {
+        init(params) {
+            this.params = params;
+            this.eGui = document.createElement('button');
+            this.eGui.innerText = 'Reset';
+            this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
+
+            this.eGui.addEventListener('click', () => {
+             const modal = document.querySelector("#modalDialog");
+             document.querySelector("#rowIndex").innerText = params.node.rowIndex;
+             document.querySelector("#scriptFullname").innerText = params.data.fullname;
+             let statusDropdown = document.querySelector("#targetStatus");
+             let currentStatus = params.data.status;
+             if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
+                 Object.keys(resetFromRejected).forEach(state => {
+                     let option = document.createElement('option');
+                     option.setAttribute('value', resetFromRejected[state]);
+                     option.innerText = state;
+                     statusDropdown.add(option);
+                 });
+             } else if (currentStatus === "REVIEWABLE") {
+                 Object.keys(resetFromReviewable).forEach(state => {
+                     let option = document.createElement('option');
+                     option.setAttribute('value', resetFromReviewable[state]);
+                     option.innerText = state;
+                     statusDropdown.add(option);
+                 });
+             } else {
+                 alert(`Cannot reset a script from ${currentStatus} status`);
+                 return;
+             }
+             //    Object.keys(resetFromRejected).forEach(state => {
+             //        // ajax form submit
+             //        // var xhr = new XMLHttpRequest();
+             //        // xhr.open("POST", '/server', true);
+             //        //
+             //        // //Send the proper header information along with the request
+             //        // xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+             //        //
+             //        // xhr.onreadystatechange = function() { // Call a function when the state changes.
+             //        //     if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
+             //        //         // Request finished. Do processing here.
+             //        //     }
+             //        // }
+             //        // xhr.send("foo=bar&lorem=ipsum");
+             //
+             //         let option = document.createElement('option');
+             //         option.setAttribute('value', resetFromRejected[state]);
+             //         option.innerText = state;
+             //         statusDropdown.add(option);
+             //     });
+             modal.showModal();
+            });
+        }
+
+        getGui() {
+            return this.eGui;
+      }
+    }
+
+    const closeModal = () => {
+      const modal = document.querySelector("#modalDialog");
+      modal.close();
+    };
+
+    const updateStatus = () => {
+        const modal = document.querySelector("#modalDialog");
+
+        let resetObj = {
+            fullname: String(document.querySelector("#scriptFullname").innerText),
+            status: parseInt(document.querySelector("#targetStatus").value),
+        };
+
+        let resetJson = JSON.stringify(resetObj);
+        console.log(resetJson);
+
+        const url = "{{url_for('reset_script')}}";
+        let xhr = new XMLHttpRequest();
+        xhr.open('POST', url, true);
+        xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+        xhr.onload = function () {
+            console.log(xhr.responseText);
+
+            if (xhr.status === 201) {
+                const rowIndex = Number(document.querySelector("#rowIndex").innerText);
+                const newStatus = document.querySelector("#targetStatus").value;
+                scriptGridApi.getRowNode(rowIndex).setDataValue("status", newStatus);
+                modal.close();
+            } else {
+                console.error("Error:", xhr.responseText);
+                alert("Error resetting the script");
+                modal.close();
+            }
+        };
+        xhr.onerror = function () {
+            console.error("Request failed");
+            modal.close();
+        };
+        xhr.send(resetJson);
+    };
+
     const scriptsGridOptions = {
-        // rowData: scriptsJson,
         columnDefs: [
             {field: "name", flex: 1, cellRenderer: ScriptNameRenderer,},
             {field: "status", flex: 1},
-            {field: "superseded", flex: 1}
+            {field: "superseded", flex: 1},
+            {
+                headerName: 'Actions',
+                field: 'editButton',
+                cellRenderer: ButtonCellRenderer,
+                editable: false,
+                width: 200,
+              },
         ]
     };
     const groupsGridOptions = {
-        // rowData: groupsJson,
         rowHeight: 120,
         columnDefs: [
             {field: "name", flex: 1, filter: true, cellRenderer: GroupNameRenderer},
@@ -91,10 +209,12 @@
             {field: "spec_aliases", flex: 2, cellRenderer: DictRenderer},
         ]
     };
+
+    let scriptGridApi;
     const populateScriptGrid = (scriptsJson) => {
         scriptsGridOptions.rowData = scriptsJson;
         const scriptsGridElement = document.getElementById("scriptsGrid");
-        agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
+        scriptGridApi = agGrid.createGrid(scriptsGridElement, scriptsGridOptions);
     };
 
     const populateGroupsGrid = (groupsJson) => {
@@ -140,8 +260,10 @@
 </nav>
 <div id="step_content" class="w-full"
      hx-get="{{ url_for('get_step', campaign_id=campaign_id, step_id=step.id) }}"
-     hx-trigger="every 20s" hx-select="#step_content" hx-swap="outerHTML">
+     hx-trigger="every 20s"
+     hx-select="#step_content" hx-swap="outerHTML">
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
+        <div class="htmx-indicator">Updating...</div>
         <div class="flex items-center">
             <span class="text-2xl font-bold">{{step.name}}</span>
         </div>

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% include "partials/reset_script_modal.html" %}
 {% include "partials/error_modal.html" %}
+{% include "partials/script_log_modal.html" %}
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -6,6 +6,16 @@
 {% include "partials/script_log_modal.html" %}
 <script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    let stepScripts;
+    let stepGroups;
+</script>
+<script hx-swap-oob="outerHTML:#grid_data" id="grid_data">
+    // Update data objects with every htmx reload
+    // to reflect any db changes
+    stepScripts = {{scripts|sort(attribute="id")|tojson}};
+    stepGroups = {{groups|sort(attribute="id")|tojson}};
+</script>
+<script>
     const reset_script_endpoint = "{{url_for('reset_script')}}";
     class GroupNameRenderer {
         eGui;
@@ -115,8 +125,6 @@
         agGrid.createGrid(groupsGridElement, groupsGridOptions);
     };
 
-    let stepScripts;
-    let stepGroups;
     const populateGrids = () => {
         populateScriptGrid(stepScripts);
         populateGroupsGrid(stepGroups)
@@ -153,10 +161,6 @@
      hx-get="{{ url_for('get_step', campaign_id=campaign_id, step_id=step.id) }}"
      hx-trigger="every 20s"
      hx-select="#step_content" hx-swap="outerHTML">
-    <script>
-        stepScripts = {{scripts|sort(attribute="id")|tojson}};
-        stepGroups = {{groups|sort(attribute="id")|tojson}};
-    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="htmx-indicator">Updating...</div>
         <div class="flex items-center">

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -2,6 +2,7 @@
 {% block title %} Step Details {% endblock %}
 {% block content %}
 {% include "partials/reset_script_modal.html" %}
+{% include "partials/error_modal.html" %}
 <script>
     class GroupNameRenderer {
         eGui;
@@ -82,6 +83,13 @@
         ACCEPTED: 5,
         REJECTED: -3,
     };
+
+    const resetScriptModal = document.querySelector("#modalDialog");
+    const errorModal = document.querySelector("#errorModal");
+    const closeErrModalBtn = document.querySelector("[close-error-modal]");
+    closeErrModalBtn.addEventListener("click", () => errorModal.close());
+    const errorMessage = document.querySelector("[error-message]")
+
     class ButtonCellRenderer {
         init(params) {
             this.params = params;
@@ -90,7 +98,7 @@
             this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
 
             this.eGui.addEventListener('click', () => {
-             const modal = document.querySelector("#modalDialog");
+
              document.querySelector("#rowIndex").innerText = params.node.rowIndex;
              document.querySelector("#scriptFullname").innerText = params.data.fullname;
              let statusDropdown = document.querySelector("#targetStatus");
@@ -110,30 +118,31 @@
                      statusDropdown.add(option);
                  });
              } else {
-                 alert(`Cannot reset a script from ${currentStatus} status`);
+                 errorModal.showModal();
+                 errorMessage.innerText = `Cannot reset a script from ${currentStatus} status`;
                  return;
              }
-             //    Object.keys(resetFromRejected).forEach(state => {
-             //        // ajax form submit
-             //        // var xhr = new XMLHttpRequest();
-             //        // xhr.open("POST", '/server', true);
-             //        //
-             //        // //Send the proper header information along with the request
-             //        // xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-             //        //
-             //        // xhr.onreadystatechange = function() { // Call a function when the state changes.
-             //        //     if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
-             //        //         // Request finished. Do processing here.
-             //        //     }
-             //        // }
-             //        // xhr.send("foo=bar&lorem=ipsum");
-             //
-             //         let option = document.createElement('option');
-             //         option.setAttribute('value', resetFromRejected[state]);
-             //         option.innerText = state;
-             //         statusDropdown.add(option);
-             //     });
-             modal.showModal();
+                // Object.keys(resetFromRejected).forEach(state => {
+                //     // ajax form submit
+                //     // var xhr = new XMLHttpRequest();
+                //     // xhr.open("POST", '/server', true);
+                //     //
+                //     // //Send the proper header information along with the request
+                //     // xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+                //     //
+                //     // xhr.onreadystatechange = function() { // Call a function when the state changes.
+                //     //     if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
+                //     //         // Request finished. Do processing here.
+                //     //     }
+                //     // }
+                //     // xhr.send("foo=bar&lorem=ipsum");
+                //
+                //      let option = document.createElement('option');
+                //      option.setAttribute('value', resetFromRejected[state]);
+                //      option.innerText = state;
+                //      statusDropdown.add(option);
+                //  });
+             resetScriptModal.showModal();
             });
         }
 
@@ -143,13 +152,10 @@
     }
 
     const closeModal = () => {
-      const modal = document.querySelector("#modalDialog");
-      modal.close();
+      resetScriptModal.close();
     };
 
     const updateStatus = () => {
-        const modal = document.querySelector("#modalDialog");
-
         let resetObj = {
             fullname: String(document.querySelector("#scriptFullname").innerText),
             status: parseInt(document.querySelector("#targetStatus").value),
@@ -169,16 +175,17 @@
                 const rowIndex = Number(document.querySelector("#rowIndex").innerText);
                 const newStatus = document.querySelector("#targetStatus").value;
                 scriptGridApi.getRowNode(rowIndex).setDataValue("status", newStatus);
-                modal.close();
+                resetScriptModal.close();
             } else {
-                console.error("Error:", xhr.responseText);
-                alert("Error resetting the script");
-                modal.close();
+                resetScriptModal.close();
+                errorModal.showModal();
+                errorMessage.innerText = 'Error resetting script!';
             }
         };
         xhr.onerror = function () {
             console.error("Request failed");
-            modal.close();
+            alert('Error resetting script!');
+            resetScriptModal.close();
         };
         xhr.send(resetJson);
     };

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -3,7 +3,9 @@
 {% block content %}
 {% include "partials/reset_script_modal.html" %}
 {% include "partials/error_modal.html" %}
+<script src="{{ url_for('static', path='/js/script-grid-utils.js') }}"></script>
 <script>
+    const reset_script_endpoint = "{{url_for('reset_script')}}";
     class GroupNameRenderer {
         eGui;
 
@@ -26,25 +28,24 @@
     }
     // scripts
     class ScriptNameRenderer {
-        eGui;
-
-     init(params) {
-       let scriptName = document.createElement('a');
-       scriptName.textContent = params.data.name;
-       scriptName.href = `{{url_for("get_script", campaign_id=campaign_id, step_id=step.id, script_id="${params.data.id}")}}`;
-       scriptName.setAttribute('class', 'font-bold text-teal-700 underline underline-offset-4 decoration-2 hover:text-gray-500');
-       this.eGui = document.createElement('span');
-       this.eGui.appendChild(scriptName)
-     }
+    eGui;
+    init(params) {
+        let scriptName = document.createElement('a');
+        scriptName.textContent = params.data.name;
+        scriptName.href = `{{url_for("get_script", campaign_id=campaign_id, step_id=step.id, script_id="${params.data.id}")}}`;
+        scriptName.setAttribute('class', 'font-bold text-teal-700 underline underline-offset-4 decoration-2 hover:text-gray-500');
+        this.eGui = document.createElement('span');
+        this.eGui.appendChild(scriptName)
+    }
 
      getGui() {
-       return this.eGui;
+        return this.eGui;
      }
 
      refresh(params) {
-         return false
+        return false;
      }
-    }
+}
 
     // groups
     class DictRenderer {
@@ -72,124 +73,6 @@
      }
     }
 
-    // list of statuses to reset to if current status is failed or rejected
-    const resetFromRejected = {
-        WAITING: 0,
-        READY: 1,
-        PREPARED: 2
-    };
-
-    const resetFromReviewable = {
-        ACCEPTED: 5,
-        REJECTED: -3,
-    };
-
-    const resetScriptModal = document.querySelector("#modalDialog");
-    const errorModal = document.querySelector("#errorModal");
-    const closeErrModalBtn = document.querySelector("[close-error-modal]");
-    closeErrModalBtn.addEventListener("click", () => errorModal.close());
-    const errorMessage = document.querySelector("[error-message]")
-
-    class ButtonCellRenderer {
-        init(params) {
-            this.params = params;
-            this.eGui = document.createElement('button');
-            this.eGui.innerText = 'Reset';
-            this.eGui.setAttribute('class', 'mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50');
-
-            this.eGui.addEventListener('click', () => {
-
-             document.querySelector("#rowIndex").innerText = params.node.rowIndex;
-             document.querySelector("#scriptFullname").innerText = params.data.fullname;
-             let statusDropdown = document.querySelector("#targetStatus");
-             let currentStatus = params.data.status;
-             if(currentStatus === "FAILED" || currentStatus === "REJECTED"){
-                 Object.keys(resetFromRejected).forEach(state => {
-                     let option = document.createElement('option');
-                     option.setAttribute('value', resetFromRejected[state]);
-                     option.innerText = state;
-                     statusDropdown.add(option);
-                 });
-             } else if (currentStatus === "REVIEWABLE") {
-                 Object.keys(resetFromReviewable).forEach(state => {
-                     let option = document.createElement('option');
-                     option.setAttribute('value', resetFromReviewable[state]);
-                     option.innerText = state;
-                     statusDropdown.add(option);
-                 });
-             } else {
-                 errorModal.showModal();
-                 errorMessage.innerText = `Cannot reset a script from ${currentStatus} status`;
-                 return;
-             }
-                // Object.keys(resetFromRejected).forEach(state => {
-                //     // ajax form submit
-                //     // var xhr = new XMLHttpRequest();
-                //     // xhr.open("POST", '/server', true);
-                //     //
-                //     // //Send the proper header information along with the request
-                //     // xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-                //     //
-                //     // xhr.onreadystatechange = function() { // Call a function when the state changes.
-                //     //     if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
-                //     //         // Request finished. Do processing here.
-                //     //     }
-                //     // }
-                //     // xhr.send("foo=bar&lorem=ipsum");
-                //
-                //      let option = document.createElement('option');
-                //      option.setAttribute('value', resetFromRejected[state]);
-                //      option.innerText = state;
-                //      statusDropdown.add(option);
-                //  });
-             resetScriptModal.showModal();
-            });
-        }
-
-        getGui() {
-            return this.eGui;
-      }
-    }
-
-    const closeModal = () => {
-      resetScriptModal.close();
-    };
-
-    const updateStatus = () => {
-        let resetObj = {
-            fullname: String(document.querySelector("#scriptFullname").innerText),
-            status: parseInt(document.querySelector("#targetStatus").value),
-        };
-
-        let resetJson = JSON.stringify(resetObj);
-        console.log(resetJson);
-
-        const url = "{{url_for('reset_script')}}";
-        let xhr = new XMLHttpRequest();
-        xhr.open('POST', url, true);
-        xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-        xhr.onload = function () {
-            console.log(xhr.responseText);
-
-            if (xhr.status === 201) {
-                const rowIndex = Number(document.querySelector("#rowIndex").innerText);
-                const newStatus = document.querySelector("#targetStatus").value;
-                scriptGridApi.getRowNode(rowIndex).setDataValue("status", newStatus);
-                resetScriptModal.close();
-            } else {
-                resetScriptModal.close();
-                errorModal.showModal();
-                errorMessage.innerText = 'Error resetting script!';
-            }
-        };
-        xhr.onerror = function () {
-            console.error("Request failed");
-            alert('Error resetting script!');
-            resetScriptModal.close();
-        };
-        xhr.send(resetJson);
-    };
-
     const scriptsGridOptions = {
         columnDefs: [
             {field: "name", flex: 1, cellRenderer: ScriptNameRenderer,},
@@ -197,13 +80,14 @@
             {field: "superseded", flex: 1},
             {
                 headerName: 'Actions',
-                field: 'editButton',
-                cellRenderer: ButtonCellRenderer,
+                field: 'resetButton',
+                cellRenderer: ResetButtonCellRenderer,
                 editable: false,
                 width: 200,
-              },
+            },
         ]
     };
+
     const groupsGridOptions = {
         rowHeight: 120,
         columnDefs: [

--- a/src/lsst/cmservice/web_app/templates/pages/step_details.html
+++ b/src/lsst/cmservice/web_app/templates/pages/step_details.html
@@ -114,11 +114,10 @@
         agGrid.createGrid(groupsGridElement, groupsGridOptions);
     };
 
+    let stepScripts;
+    let stepGroups;
     const populateGrids = () => {
-        const stepScripts = {{scripts|tojson}};
         populateScriptGrid(stepScripts);
-
-        const stepGroups = {{groups|tojson}};
         populateGroupsGrid(stepGroups)
     };
     window.addEventListener("DOMContentLoaded", function() {
@@ -153,6 +152,10 @@
      hx-get="{{ url_for('get_step', campaign_id=campaign_id, step_id=step.id) }}"
      hx-trigger="every 20s"
      hx-select="#step_content" hx-swap="outerHTML">
+    <script>
+        stepScripts = {{scripts|sort(attribute="id")|tojson}};
+        stepGroups = {{groups|sort(attribute="id")|tojson}};
+    </script>
     <div class="overflow-hidden px-4 py-5 sm:p-6 relative w-1/2">
         <div class="htmx-indicator">Updating...</div>
         <div class="flex items-center">

--- a/src/lsst/cmservice/web_app/templates/partials/error_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/error_modal.html
@@ -10,7 +10,7 @@
             </svg>
           </div>
           <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Cannot reset script</h3>
+            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Something went wrong!</h3>
             <div class="mt-2">
               <p class="text-sm text-gray-500" error-message></p>
             </div>

--- a/src/lsst/cmservice/web_app/templates/partials/error_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/error_modal.html
@@ -1,4 +1,4 @@
-<dialog id="errorModal" class="relative z-10" aria-labelledby="modal-title">
+<dialog id="errorModal" class="relative z-10" aria-labelledby="error-modal-title">
 
   <div class="fixed inset-0 z-10 overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -10,7 +10,7 @@
             </svg>
           </div>
           <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Something went wrong!</h3>
+            <h3 class="text-base font-semibold text-gray-900" id="error-modal-title">Something went wrong!</h3>
             <div class="mt-2">
               <p class="text-sm text-gray-500" error-message></p>
             </div>

--- a/src/lsst/cmservice/web_app/templates/partials/error_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/error_modal.html
@@ -1,0 +1,25 @@
+<dialog id="errorModal" class="relative z-10" aria-labelledby="modal-title">
+
+  <div class="fixed inset-0 z-10 overflow-y-auto">
+    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10">
+            <svg class="size-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+            </svg>
+          </div>
+          <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Cannot reset script</h3>
+            <div class="mt-2">
+              <p class="text-sm text-gray-500" error-message></p>
+            </div>
+          </div>
+        </div>
+        <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+          <button close-error-modal type="button" class="mt-3 inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
@@ -8,8 +8,8 @@
             <span id="scriptFullname" class="hidden"></span>
             <div>
               <label for="scriptLogUrl" class="text-sm/6 font-medium text-gray-900">Script Log URL</label>
-              <div class="mt-2 text-xs">
-                <div id="scriptLogUrl" class="pb-3"></div>
+              <div class="text-xs">
+                <span id="scriptLogUrl" class="pb-3 pr-2"></span><button id="showLogBtn" class="mt-2 rounded bg-white px-2 py-1 text-xs font-semibold text-teal-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">Show Log</button>
               </div>
             </div>
             <div>

--- a/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
@@ -1,0 +1,33 @@
+<dialog id="modalDialog" class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+  <div class="fixed inset-0 bg-gray-500/75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
+        <div>
+          <div class="mt-3 text-center sm:mt-5">
+            <h2 class="text-base font-semibold text-gray-900" id="modal-title">Reset script</h2>
+<!--            <div class="mt-2">-->
+<!--                <span id="rowIndex" class="hidden"></span>-->
+<!--                <label>New status</label>-->
+<!--                <select id="targetStatus"></select>-->
+<!--            </div>-->
+
+            <div class="sm:col-span-3">
+              <span id="rowIndex" class="hidden"></span>
+              <span id="scriptFullname" class="hidden"></span>
+              <label for="targetStatus" class="text-sm/6 font-medium text-gray-900">Target Status</label>
+              <div class="mt-2">
+                <select id="targetStatus" name="targetStatus" class="w-full rounded border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-teal-600 sm:max-w-xs sm:text-sm/6">
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+          <button type="button" onclick="updateStatus()" class="inline-flex w-full justify-center rounded bg-teal-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:col-start-2">Confirm</button>
+          <button type="button" onclick="closeModal()" class="mt-3 inline-flex w-full justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
@@ -6,12 +6,6 @@
         <div>
           <div class="mt-3 text-center sm:mt-5">
             <h2 class="text-base font-semibold text-gray-900" id="modal-title">Reset script</h2>
-<!--            <div class="mt-2">-->
-<!--                <span id="rowIndex" class="hidden"></span>-->
-<!--                <label>New status</label>-->
-<!--                <select id="targetStatus"></select>-->
-<!--            </div>-->
-
             <div class="sm:col-span-3">
               <span id="rowIndex" class="hidden"></span>
               <span id="scriptFullname" class="hidden"></span>
@@ -24,8 +18,8 @@
           </div>
         </div>
         <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-          <button type="button" onclick="updateStatus()" class="inline-flex w-full justify-center rounded bg-teal-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:col-start-2">Confirm</button>
-          <button type="button" onclick="closeModal()" class="mt-3 inline-flex w-full justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
+          <button confirm-reset type="button" class="inline-flex w-full justify-center rounded bg-teal-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:col-start-2">Confirm</button>
+          <button close-reset-modal type="button" class="mt-3 inline-flex w-full justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
         </div>
       </div>
     </div>

--- a/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
@@ -2,7 +2,7 @@
       <div class="relative transform overflow-hidden bg-white px-4 pb-4 pt-5 text-left">
         <div>
           <div class="mt-3 text-center sm:mt-5">
-            <h2 class="text-base font-semibold text-gray-900" id="modal-title"></h2>
+            <h2 class="text-base font-semibold text-gray-900" id="reset-modal-title"></h2>
           </div>
             <span id="rowIndex" class="hidden"></span>
             <span id="scriptFullname" class="hidden"></span>

--- a/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/reset_script_modal.html
@@ -1,27 +1,30 @@
-<dialog id="modalDialog" class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="fixed inset-0 bg-gray-500/75 transition-opacity" aria-hidden="true"></div>
-  <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
-    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
+<dialog id="modalDialog" aria-labelledby="modal-title" role="dialog" aria-modal="true" class="rounded-lg w-1/2">
+      <div class="relative transform overflow-hidden bg-white px-4 pb-4 pt-5 text-left">
         <div>
           <div class="mt-3 text-center sm:mt-5">
-            <h2 class="text-base font-semibold text-gray-900" id="modal-title">Reset script</h2>
-            <div class="sm:col-span-3">
-              <span id="rowIndex" class="hidden"></span>
-              <span id="scriptFullname" class="hidden"></span>
+            <h2 class="text-base font-semibold text-gray-900" id="modal-title"></h2>
+          </div>
+            <span id="rowIndex" class="hidden"></span>
+            <span id="scriptFullname" class="hidden"></span>
+            <div>
+              <label for="scriptLogUrl" class="text-sm/6 font-medium text-gray-900">Script Log URL</label>
+              <div class="mt-2 text-xs">
+                <div id="scriptLogUrl" class="pb-3"></div>
+              </div>
+            </div>
+            <div>
               <label for="targetStatus" class="text-sm/6 font-medium text-gray-900">Target Status</label>
               <div class="mt-2">
                 <select id="targetStatus" name="targetStatus" class="w-full rounded border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-teal-600 sm:max-w-xs sm:text-sm/6">
                 </select>
               </div>
             </div>
-          </div>
+
         </div>
-        <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-          <button confirm-reset type="button" class="inline-flex w-full justify-center rounded bg-teal-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:col-start-2">Confirm</button>
-          <button close-reset-modal type="button" class="mt-3 inline-flex w-full justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
+        <div class="mt-5 sm:mt-6 sm:flex sm:flex-row-reverse gap-x-3">
+          <button confirm-reset type="button" class="inline-flex justify-center rounded bg-teal-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:col-start-2">Confirm</button>
+          <button close-reset-modal type="button" class="mt-3 inline-flex justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
         </div>
-      </div>
+
     </div>
-  </div>
 </dialog>

--- a/src/lsst/cmservice/web_app/templates/partials/script_log_modal.html
+++ b/src/lsst/cmservice/web_app/templates/partials/script_log_modal.html
@@ -1,0 +1,26 @@
+<dialog id="scriptLogModal" aria-labelledby="modal-title" role="dialog" aria-modal="true" class="rounded-lg w-1/2 h-5/6">
+      <div class="relative transform overflow-hidden bg-white px-4 pb-4 pt-5 text-left">
+        <div>
+          <div class="mt-3 text-center sm:mt-5">
+            <h2 class="text-base font-semibold text-gray-900">Script Log</h2>
+          </div>
+          <div>
+            <div class="mt-2 text-xs">
+              <div id="scriptLog" class="pb-3">
+                <textarea
+                        id="scriptLogContent"
+                        rows="4"
+                        name="comment"
+                        id="comment"
+                        readonly
+                        class="block h-3/4 w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-teal-600 sm:text-sm/6"></textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mt-5 sm:mt-6 sm:flex sm:flex-row-reverse gap-x-3">
+          <button close-log-modal type="button" class="mt-3 inline-flex justify-center rounded bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Close</button>
+        </div>
+
+    </div>
+</dialog>

--- a/tests/web_app/test_group_details_page.py
+++ b/tests/web_app/test_group_details_page.py
@@ -126,9 +126,9 @@ def test_group_details_page() -> None:
             ),
         ).not_to_be_empty()
         # check wms task progress
-        expect(page.locator(".bg-teal-700").nth(1)).to_have_attribute("style", "width: 101%")
-        expect(page.locator(".bg-teal-700").nth(1)).to_have_text("Running 8858")
-        expect(page.locator(".bg-teal-700").nth(1).locator(".tooltip")).to_contain_text("Running")
+        expect(page.locator(".bg-teal-700").nth(2)).to_have_attribute("style", "width: 101%")
+        expect(page.locator(".bg-teal-700").nth(2)).to_have_text("Running 8858")
+        expect(page.locator(".bg-teal-700").nth(2).locator(".tooltip")).to_contain_text("Running")
         expect(page.locator(".bg-green-500")).to_have_attribute("style", "width: 1%")
         expect(page.locator(".bg-green-500")).to_have_text("Succeeded 1")
         expect(page.locator(".bg-green-500").locator(".tooltip")).to_contain_text("Succeeded")

--- a/tests/web_app/test_job_details_page.py
+++ b/tests/web_app/test_job_details_page.py
@@ -140,9 +140,11 @@ def test_job_details_page() -> None:
         )
         expect(page.locator("#scriptsGrid").get_by_role("row").nth(3)).to_contain_text("WAITING")
         # check first reset button is disabled
-        expect(page.locator("#scriptsGrid").get_by_role("row").nth(1).get_by_role("button")).to_be_disabled()
+        expect(
+            page.locator("#scriptsGrid").get_by_role("row").nth(1).get_by_role("button")
+        ).not_to_be_visible()
         # check third reset button is enabled and has test "Reset"
-        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_be_enabled()
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_be_visible()
         expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_have_text(
             "Reset"
         )
@@ -165,7 +167,9 @@ def test_job_details_page() -> None:
         page.locator("[confirm-reset]").click()
         expect(page.locator("#modalDialog")).not_to_be_visible()
         expect(page.locator("#scriptsGrid").get_by_role("row").nth(3)).to_contain_text("WAITING")
-        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_be_disabled()
+        expect(
+            page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")
+        ).not_to_be_visible()
 
         # check products grid exists
         expect(page.locator("#productsGrid")).to_be_visible()

--- a/tests/web_app/test_job_details_page.py
+++ b/tests/web_app/test_job_details_page.py
@@ -108,9 +108,9 @@ def test_job_details_page() -> None:
             page.get_by_text("job_run: 2.2i/runs/test-med-1/w_2024_28/DM-45212d/step1/group1/job_000"),
         ).not_to_be_empty()
         # check wms task progress
-        expect(page.locator(".bg-teal-700").nth(1)).to_have_attribute("style", "width: 95%")
-        expect(page.locator(".bg-teal-700").nth(1)).to_have_text("Running 4940")
-        expect(page.locator(".bg-teal-700").nth(1).locator(".tooltip")).to_contain_text("Running")
+        expect(page.locator(".bg-teal-700").nth(2)).to_have_attribute("style", "width: 95%")
+        expect(page.locator(".bg-teal-700").nth(2)).to_have_text("Running 4940")
+        expect(page.locator(".bg-teal-700").nth(2).locator(".tooltip")).to_contain_text("Running")
         expect(page.locator(".bg-green-500")).to_have_attribute("style", "width: 7%")
         expect(page.locator(".bg-green-500")).to_have_text("Succeeded 331")
         expect(page.locator(".bg-green-500").locator(".tooltip")).to_contain_text("Succeeded")
@@ -138,10 +138,38 @@ def test_job_details_page() -> None:
             "href",
             "http://0.0.0.0:8080/web_app/script/13/117/75/75/540/",
         )
-        expect(page.locator("#scriptsGrid").get_by_role("row").nth(3)).to_contain_text("IN_PROGRESS")
-        # check scripts grid exists
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(3)).to_contain_text("WAITING")
+        # check first reset button is disabled
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(1).get_by_role("button")).to_be_disabled()
+        # check third reset button is enabled and has test "Reset"
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_be_enabled()
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_have_text(
+            "Reset"
+        )
+        # Reset modal dialog should be visible after clicking "Reset" button
+        page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button").click()
+        expect(page.locator("#modalDialog")).to_be_visible()
+        # Reset modal dialog should have title "Reset Script"
+        expect(page.locator("#reset-modal-title")).to_have_text("Reset Script")
+        # Target Status dropdown in Reset modal dialog
+        # should have a first option "WAITING"
+        expect(page.locator("#targetStatus").locator("option").first).to_have_text("WAITING")
+        # Reset Modal should not be visible after clicking the cancel button
+        page.locator("[close-reset-modal]").click()
+        expect(page.locator("#modalDialog")).not_to_be_visible()
+        # Script status should be changed to "WAITING" and Reset button
+        # should be disabled after resetting to "WAITING" in the reset modal
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2)).to_contain_text("FAILED")
+        page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button").click()
+        expect(page.locator("#targetStatus")).to_have_value("0")
+        page.locator("[confirm-reset]").click()
+        expect(page.locator("#modalDialog")).not_to_be_visible()
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(3)).to_contain_text("WAITING")
+        expect(page.locator("#scriptsGrid").get_by_role("row").nth(2).get_by_role("button")).to_be_disabled()
+
+        # check products grid exists
         expect(page.locator("#productsGrid")).to_be_visible()
-        # check number of step scripts (only 1 header row)
+        # check number of step products (only 1 header row)
         expect(page.locator("#productsGrid").get_by_role("row")).to_have_count(1)
         context.close()
         browser.close()


### PR DESCRIPTION
- If a script is in FAILED or REJECTED state, It could be reset to WAITING/READEY/PREPARED
- If a script is REVIEWABLE, it could be changed to ACCEPTED/REJECTED,
- Display a popup to select the status to reset to depending on the current state and confirm/cancel buttons Also display a link to the script log file (specially if the state is REVIEWABLE)
- The dialog content should distinguish between resetting a failed script and reviewing a script
- Button text should change according to state or just be disabled if the state doesn't allow resetting/reviewing
- Display Script log URL (which is actually a path on the server) as link. Clicking the link should open file contents in another pop in read-only mode (allowing scrolling, copying content)