### PR TITLE
DM-47995 Refactor API Routers

### DIFF
--- a/src/lsst/cmservice/config.py
+++ b/src/lsst/cmservice/config.py
@@ -194,7 +194,7 @@ class AsgiConfiguration(BaseModel):
 
     prefix: str = Field(
         description="The URL prefix for the cm-service API",
-        default="/cm-service/v1",
+        default="/cmservice",
     )
 
     frontend_prefix: str = Field(

--- a/src/lsst/cmservice/main.py
+++ b/src/lsst/cmservice/main.py
@@ -11,28 +11,9 @@ from safir.middleware.x_forwarded import XForwardedMiddleware
 from . import __version__
 from .config import config
 from .routers import (
-    actions,
-    campaigns,
-    groups,
     healthz,
     index,
-    jobs,
-    loaders,
-    pipetask_error_types,
-    pipetask_errors,
-    product_sets,
-    productions,
-    queues,
-    script_dependencies,
-    script_errors,
-    script_templates,
-    scripts,
-    spec_blocks,
-    specifications,
-    step_dependencies,
-    steps,
-    task_sets,
-    wms_task_reports,
+    v1,
 )
 from .web_app import web_app
 
@@ -137,41 +118,17 @@ app = FastAPI(
     lifespan=lifespan,
     title=config.asgi.title,
     version=__version__,
-    openapi_url=f"{config.asgi.prefix}/openapi.json",
+    openapi_url="/openapi.json",
     openapi_tags=tags_metadata,
-    docs_url=f"{config.asgi.prefix}/docs",
-    redoc_url=f"{config.asgi.prefix}/redoc",
+    docs_url="/docs",
+    redoc_url="/redoc",
 )
 
 app.add_middleware(XForwardedMiddleware)
 
-app.include_router(healthz.health_router)
-app.include_router(index.router)
-app.include_router(loaders.router, prefix=config.asgi.prefix)
-app.include_router(actions.router, prefix=config.asgi.prefix)
-
-app.include_router(productions.router, prefix=config.asgi.prefix)
-app.include_router(campaigns.router, prefix=config.asgi.prefix)
-app.include_router(steps.router, prefix=config.asgi.prefix)
-app.include_router(groups.router, prefix=config.asgi.prefix)
-app.include_router(jobs.router, prefix=config.asgi.prefix)
-app.include_router(scripts.router, prefix=config.asgi.prefix)
-
-app.include_router(specifications.router, prefix=config.asgi.prefix)
-app.include_router(spec_blocks.router, prefix=config.asgi.prefix)
-app.include_router(script_templates.router, prefix=config.asgi.prefix)
-
-app.include_router(pipetask_error_types.router, prefix=config.asgi.prefix)
-app.include_router(pipetask_errors.router, prefix=config.asgi.prefix)
-app.include_router(script_errors.router, prefix=config.asgi.prefix)
-
-app.include_router(task_sets.router, prefix=config.asgi.prefix)
-app.include_router(product_sets.router, prefix=config.asgi.prefix)
-app.include_router(wms_task_reports.router, prefix=config.asgi.prefix)
-
-app.include_router(script_dependencies.router, prefix=config.asgi.prefix)
-app.include_router(step_dependencies.router, prefix=config.asgi.prefix)
-app.include_router(queues.router, prefix=config.asgi.prefix)
+app.include_router(healthz.health_router, prefix="")
+app.include_router(index.router, prefix="")
+app.include_router(v1.router, prefix=config.asgi.prefix)
 
 # Start the frontend web application.
 app.mount(config.asgi.frontend_prefix, web_app)

--- a/src/lsst/cmservice/routers/v1.py
+++ b/src/lsst/cmservice/routers/v1.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter
+
+from . import (
+    actions,
+    campaigns,
+    groups,
+    jobs,
+    loaders,
+    pipetask_error_types,
+    pipetask_errors,
+    product_sets,
+    productions,
+    queues,
+    script_dependencies,
+    script_errors,
+    script_templates,
+    scripts,
+    spec_blocks,
+    specifications,
+    step_dependencies,
+    steps,
+    task_sets,
+    wms_task_reports,
+)
+
+router = APIRouter(
+    prefix="/v1",
+)
+
+router.include_router(loaders.router)
+router.include_router(actions.router)
+
+router.include_router(productions.router)
+router.include_router(campaigns.router)
+router.include_router(steps.router)
+router.include_router(groups.router)
+router.include_router(jobs.router)
+router.include_router(scripts.router)
+
+router.include_router(specifications.router)
+router.include_router(spec_blocks.router)
+router.include_router(script_templates.router)
+
+router.include_router(pipetask_error_types.router)
+router.include_router(pipetask_errors.router)
+router.include_router(script_errors.router)
+
+router.include_router(task_sets.router)
+router.include_router(product_sets.router)
+router.include_router(wms_task_reports.router)
+
+router.include_router(script_dependencies.router)
+router.include_router(step_dependencies.router)
+router.include_router(queues.router)

--- a/tests/cli/test_campaigns.py
+++ b/tests/cli/test_campaigns.py
@@ -23,10 +23,11 @@ from .util_functions import (
 
 
 @pytest.mark.asyncio()
-async def test_campaign_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_campaign_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `campaign` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     # generate a uuid to avoid collisions

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,3 +1,4 @@
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -6,9 +7,10 @@ from lsst.cmservice.client.clientconfig import client_config
 from lsst.cmservice.config import config
 
 
-def test_commands_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+def test_commands_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test miscellaneous CLI commands"""
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     result = runner.invoke(client_top, "production list")

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -14,14 +14,15 @@ from .util_functions import (
 
 
 @pytest.mark.asyncio()
-async def test_error_create_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_error_create_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test error matching in pipetask_error_type.match.
 
     Correctly match a real error to the error_type database and fail to match a
     fake error which is not in the database.
     """
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     result = runner.invoke(
@@ -38,10 +39,11 @@ async def test_error_create_cli(uvicorn: UvicornProcess) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_load_error_types_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_load_error_types_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `error_type` db table."""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     result = runner.invoke(client_top, "load error-types --yaml_file examples/error_types.yaml")

--- a/tests/cli/test_groups.py
+++ b/tests/cli/test_groups.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -20,10 +21,11 @@ from .util_functions import (
 )
 
 
-async def test_group_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_group_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `group` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     # generate a uuid to avoid collisions

--- a/tests/cli/test_jobs.py
+++ b/tests/cli/test_jobs.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -20,10 +21,11 @@ from .util_functions import (
 )
 
 
-async def test_job_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_job_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `job` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     # generate a uuid to avoid collisions

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -1,3 +1,4 @@
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -9,10 +10,11 @@ from lsst.cmservice.config import config
 from .util_functions import check_and_parse_result
 
 
-async def test_others_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_others_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `other` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     result = runner.invoke(client_top, "pipetask_error list --output yaml")

--- a/tests/cli/test_productions.py
+++ b/tests/cli/test_productions.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -12,10 +13,11 @@ from lsst.cmservice.config import config
 from .util_functions import cleanup, create_tree
 
 
-async def test_production_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_production_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `production` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     # generate a uuid to avoid collisions

--- a/tests/cli/test_steps.py
+++ b/tests/cli/test_steps.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import pytest
 from click.testing import CliRunner
 from safir.testing.uvicorn import UvicornProcess
 
@@ -20,10 +21,11 @@ from .util_functions import (
 )
 
 
-async def test_step_cli(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_step_cli(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test `step` CLI command"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     # generate a uuid to avoid collisions

--- a/tests/cli/test_trivial.py
+++ b/tests/cli/test_trivial.py
@@ -14,10 +14,11 @@ from .util_functions import (
 
 
 @pytest.mark.asyncio()
-async def test_cli_trivial_campaign(uvicorn: UvicornProcess) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_cli_trivial_campaign(uvicorn: UvicornProcess, api_version: str) -> None:
     """Test fake end to end run using example/example_trivial.yaml"""
 
-    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}"
+    client_config.service_url = f"{uvicorn.url}{config.asgi.prefix}/{api_version}"
     runner = CliRunner()
 
     yaml_file = "examples/example_trivial.yaml"

--- a/tests/routers/test_errors.py
+++ b/tests/routers/test_errors.py
@@ -11,7 +11,8 @@ from .util_functions import (
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_load_error_types_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_load_error_types_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/job` API endpoint."""
 
     yaml_file_query = models.YamlFileQuery(
@@ -19,7 +20,7 @@ async def test_load_error_types_routes(client: AsyncClient) -> None:
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/load/error_types",
+        f"{config.asgi.prefix}/{api_version}/load/error_types",
         content=yaml_file_query.model_dump_json(),
     )
     error_types = check_and_parse_response(response, list[models.PipetaskErrorType])
@@ -29,7 +30,7 @@ async def test_load_error_types_routes(client: AsyncClient) -> None:
         rematch=True,
     )
     response = await client.post(
-        f"{config.asgi.prefix}/actions/rematch_errors",
+        f"{config.asgi.prefix}/{api_version}/actions/rematch_errors",
         content=rematch_query.model_dump_json(),
     )
     matched_errors = check_and_parse_response(response, list[models.PipetaskError])

--- a/tests/routers/test_groups.py
+++ b/tests/routers/test_groups.py
@@ -20,7 +20,8 @@ from .util_functions import (
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_group_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_group_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/group` API endpoint."""
 
     # generate a uuid to avoid collisions
@@ -29,20 +30,20 @@ async def test_group_routes(client: AsyncClient) -> None:
     os.environ["CM_CONFIGS"] = "examples"
 
     # intialize a tree down to one level lower
-    await create_tree(client, LevelEnum.job, uuid_int)
+    await create_tree(client, api_version, LevelEnum.job, uuid_int)
 
-    response = await client.get(f"{config.asgi.prefix}/group/list")
+    response = await client.get(f"{config.asgi.prefix}/{api_version}/group/list")
     groups = check_and_parse_response(response, list[models.Group])
     entry = groups[0]
 
     # check get methods
-    await check_get_methods(client, entry, "group", models.Group)
+    await check_get_methods(client, api_version, entry, "group", models.Group)
 
     # check update methods
-    await check_update_methods(client, entry, "group", models.Group)
+    await check_update_methods(client, api_version, entry, "group", models.Group)
 
     # check scripts
-    await check_scripts(client, entry, "group")
+    await check_scripts(client, api_version, entry, "group")
 
     # delete everything we just made in the session
-    await cleanup(client, check_cascade=True)
+    await cleanup(client, api_version, check_cascade=True)

--- a/tests/routers/test_jobs.py
+++ b/tests/routers/test_jobs.py
@@ -22,7 +22,8 @@ from .util_functions import (
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_job_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_job_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/job` API endpoint."""
 
     # generate a uuid to avoid collisions
@@ -31,38 +32,38 @@ async def test_job_routes(client: AsyncClient) -> None:
     os.environ["CM_CONFIGS"] = "examples"
 
     # intialize a tree down to one level lower
-    await create_tree(client, LevelEnum.job, uuid_int)
+    await create_tree(client, api_version, LevelEnum.job, uuid_int)
 
-    response = await client.get(f"{config.asgi.prefix}/job/list")
+    response = await client.get(f"{config.asgi.prefix}/{api_version}/job/list")
     jobs = check_and_parse_response(response, list[models.Job])
     entry = jobs[0]
 
     # check get methods
-    await check_get_methods(client, entry, "job", models.Job)
+    await check_get_methods(client, api_version, entry, "job", models.Job)
 
     # check update methods
-    await check_update_methods(client, entry, "job", models.Job)
+    await check_update_methods(client, api_version, entry, "job", models.Job)
 
     # check scripts
-    await check_scripts(client, entry, "job")
+    await check_scripts(client, api_version, entry, "job")
 
     # check queues
-    await check_queue(client, entry)
+    await check_queue(client, api_version, entry)
 
     # test some job-specific stuff
     response = await client.get(
-        f"{config.asgi.prefix}/job/get/{entry.id}/parent",
+        f"{config.asgi.prefix}/{api_version}/job/get/{entry.id}/parent",
     )
     parent = check_and_parse_response(response, models.Group)
 
     response = await client.get(
-        f"{config.asgi.prefix}/job/get/{entry.id}/errors",
+        f"{config.asgi.prefix}/{api_version}/job/get/{entry.id}/errors",
     )
     check_errors = check_and_parse_response(response, list[models.PipetaskError])
     assert len(check_errors) == 0
 
     response = await client.get(
-        f"{config.asgi.prefix}/job/get/-1/errors",
+        f"{config.asgi.prefix}/{api_version}/job/get/-1/errors",
     )
     expect_failed_response(response, 404)
 
@@ -71,71 +72,71 @@ async def test_job_routes(client: AsyncClient) -> None:
         status=StatusEnum.rescuable,
     )
     response = await client.put(
-        f"{config.asgi.prefix}/job/update/{entry.id}",
+        f"{config.asgi.prefix}/{api_version}/job/update/{entry.id}",
         content=update_model.model_dump_json(),
     )
 
     response = await client.put(
-        f"{config.asgi.prefix}/job/update/-1",
+        f"{config.asgi.prefix}/{api_version}/job/update/-1",
         content=update_model.model_dump_json(),
     )
     expect_failed_response(response, 404)
 
     response = await client.post(
-        f"{config.asgi.prefix}/group/action/{parent.id}/rescue_job",
+        f"{config.asgi.prefix}/{api_version}/group/action/{parent.id}/rescue_job",
     )
     rescue_job = check_and_parse_response(response, models.Job)
     assert rescue_job.attempt == 1
 
     response = await client.put(
-        f"{config.asgi.prefix}/job/update/{rescue_job.id}",
+        f"{config.asgi.prefix}/{api_version}/job/update/{rescue_job.id}",
         content=update_model.model_dump_json(),
     )
 
     rescue_node_model = models.NodeQuery(fullname=parent.fullname)
 
     response = await client.post(
-        f"{config.asgi.prefix}/actions/rescue_job", content=rescue_node_model.model_dump_json()
+        f"{config.asgi.prefix}/{api_version}/actions/rescue_job", content=rescue_node_model.model_dump_json()
     )
     rescue_job = check_and_parse_response(response, models.Job)
     assert rescue_job.attempt == 2
 
     response = await client.get(
-        f"{config.asgi.prefix}/group/get/{parent.id}/jobs",
+        f"{config.asgi.prefix}/{api_version}/group/get/{parent.id}/jobs",
     )
     check_jobs = check_and_parse_response(response, list[models.Job])
     assert len(check_jobs) == 3
     new_job = check_jobs[-1]
 
     response = await client.get(
-        f"{config.asgi.prefix}/group/get/-1/jobs",
+        f"{config.asgi.prefix}/{api_version}/group/get/-1/jobs",
     )
     expect_failed_response(response, 404)
 
     update_model.status = StatusEnum.accepted
     response = await client.put(
-        f"{config.asgi.prefix}/job/update/{new_job.id}",
+        f"{config.asgi.prefix}/{api_version}/job/update/{new_job.id}",
         content=update_model.model_dump_json(),
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/group/action/{parent.id}/mark_rescued",
+        f"{config.asgi.prefix}/{api_version}/group/action/{parent.id}/mark_rescued",
     )
     check_jobs = check_and_parse_response(response, list[models.Job])
     assert len(check_jobs) == 2
 
     update_model.status = StatusEnum.rescuable
     response = await client.put(
-        f"{config.asgi.prefix}/job/update/{entry.id}",
+        f"{config.asgi.prefix}/{api_version}/job/update/{entry.id}",
         content=update_model.model_dump_json(),
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/actions/mark_job_rescued",
+        f"{config.asgi.prefix}/{api_version}/actions/mark_job_rescued",
         content=rescue_node_model.model_dump_json(),
     )
     check_jobs = check_and_parse_response(response, list[models.Job])
     assert len(check_jobs) == 2
 
     # delete everything we just made in the session
-    await cleanup(client, check_cascade=True)
+    await cleanup(client, api_version, check_cascade=True)

--- a/tests/routers/test_productions.py
+++ b/tests/routers/test_productions.py
@@ -11,7 +11,8 @@ from .util_functions import cleanup, create_tree
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_production_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_production_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/production` API endpoint."""
 
     # generate a uuid to avoid collisions
@@ -20,7 +21,7 @@ async def test_production_routes(client: AsyncClient) -> None:
     os.environ["CM_CONFIGS"] = "examples"
 
     # intialize a tree down to one level lower
-    await create_tree(client, LevelEnum.campaign, uuid_int)
+    await create_tree(client, api_version, LevelEnum.campaign, uuid_int)
 
     # delete everything we just made in the session
-    await cleanup(client, check_cascade=True)
+    await cleanup(client, api_version, check_cascade=True)

--- a/tests/routers/test_reports.py
+++ b/tests/routers/test_reports.py
@@ -16,7 +16,8 @@ from .util_functions import (
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_report_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_report_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/job` API endpoint."""
 
     # generate a uuid to avoid collisions
@@ -25,9 +26,9 @@ async def test_report_routes(client: AsyncClient) -> None:
     os.environ["CM_CONFIGS"] = "examples"
 
     # intialize a tree down to one level lower
-    await create_tree(client, LevelEnum.job, uuid_int)
+    await create_tree(client, api_version, LevelEnum.job, uuid_int)
 
-    response = await client.get(f"{config.asgi.prefix}/job/list")
+    response = await client.get(f"{config.asgi.prefix}/{api_version}/job/list")
     jobs = check_and_parse_response(response, list[models.Job])
     entry = jobs[0]
 
@@ -37,7 +38,7 @@ async def test_report_routes(client: AsyncClient) -> None:
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/load/manifest_report",
+        f"{config.asgi.prefix}/{api_version}/load/manifest_report",
         content=manifest_report_query.model_dump_json(),
     )
     assert response.is_success

--- a/tests/routers/test_steps.py
+++ b/tests/routers/test_steps.py
@@ -20,7 +20,8 @@ from .util_functions import (
 
 @pytest.mark.asyncio()
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_step_routes(client: AsyncClient) -> None:
+@pytest.mark.parametrize("api_version", ["v1"])
+async def test_step_routes(client: AsyncClient, api_version: str) -> None:
     """Test `/step` API endpoint."""
 
     # generate a uuid to avoid collisions
@@ -29,20 +30,20 @@ async def test_step_routes(client: AsyncClient) -> None:
     os.environ["CM_CONFIGS"] = "examples"
 
     # intialize a tree down to one level lower
-    await create_tree(client, LevelEnum.group, uuid_int)
+    await create_tree(client, api_version, LevelEnum.group, uuid_int)
 
-    response = await client.get(f"{config.asgi.prefix}/step/list")
+    response = await client.get(f"{config.asgi.prefix}/{api_version}/step/list")
     steps = check_and_parse_response(response, list[models.Step])
     entry = steps[0]
 
     # check get methods
-    await check_get_methods(client, entry, "step", models.Step)
+    await check_get_methods(client, api_version, entry, "step", models.Step)
 
     # check update methods
-    await check_update_methods(client, entry, "step", models.Step)
+    await check_update_methods(client, api_version, entry, "step", models.Step)
 
     # check scripts
-    await check_scripts(client, entry, "step")
+    await check_scripts(client, api_version, entry, "step")
 
     # delete everything we just made in the session
-    await cleanup(client, check_cascade=True)
+    await cleanup(client, api_version, check_cascade=True)

--- a/tests/routers/test_trivial.py
+++ b/tests/routers/test_trivial.py
@@ -13,8 +13,10 @@ from .util_functions import (
 
 
 @pytest.mark.asyncio()
+@pytest.mark.parametrize("api_version", ["v1"])
 async def test_routers_trivial_campaign(
     client: AsyncClient,
+    api_version: str,
 ) -> None:
     """Test fake end to end run using example/example_trivial.yaml"""
 
@@ -25,7 +27,7 @@ async def test_routers_trivial_campaign(
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/load/specification",
+        f"{config.asgi.prefix}/{api_version}/load/specification",
         content=spec_load_model.model_dump_json(),
     )
     specification = check_and_parse_response(response, models.Specification)
@@ -39,11 +41,11 @@ async def test_routers_trivial_campaign(
     )
 
     response = await client.post(
-        f"{config.asgi.prefix}/load/campaign",
+        f"{config.asgi.prefix}/{api_version}/load/campaign",
         content=campaign_load_model.model_dump_json(),
     )
     campaign = check_and_parse_response(response, models.Campaign)
     assert campaign.name == "test"
 
     # delete everything we just made in the session
-    await cleanup(client)
+    await cleanup(client, api_version)


### PR DESCRIPTION
Refactors FastAPI routers to increase flexibility. Previously, all routes are added to the root FastAPI application with a hard-coded prefix (`cmservice/v1`). This PR removes the `v1` from the static prefix and delegates the API version to a sub router and attaches all current routers to it instead of the root app.

Documentation pages are attached to the URI root ("/") instead of to any prefix or sub router. The index and healthz routes are also attached to the URI root.