### PR TITLE
DM-51397 Update DB Session Handling and Typing for Py3.12

### DIFF
--- a/src/lsst/cmservice/cli/wrappers.py
+++ b/src/lsst/cmservice/cli/wrappers.py
@@ -11,7 +11,7 @@ apply to all RowMixin, NodeMixin and ElementMixin classes.
 import json
 from collections.abc import Callable, Sequence
 from enum import Enum
-from typing import Any, TypeAlias
+from typing import Any
 
 import click
 import yaml
@@ -20,7 +20,7 @@ from tabulate import tabulate
 
 from ..client.client import CMClient
 from ..common.enums import StatusEnum
-from ..db import Job, Script, SpecBlock, Specification
+from ..db import ElementMixin, Job, RowMixin, Script, SpecBlock, Specification
 from . import options
 
 
@@ -127,7 +127,7 @@ def output_dict(
 def get_list_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that gets all the rows from a table
     and attaches that function to the cli.
@@ -143,7 +143,7 @@ def get_list_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -170,7 +170,7 @@ def get_list_command(
 def get_row_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that gets a row from a table
     and attaches that function to the cli.
@@ -183,7 +183,7 @@ def get_row_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -212,7 +212,7 @@ def get_row_command(
 def get_row_by_name_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that gets a row from a table
     and attaches that function to the cli.
@@ -225,7 +225,7 @@ def get_row_by_name_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -254,7 +254,7 @@ def get_row_by_name_command(
 def get_row_by_fullname_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that gets a row from a table
     and attaches that function to the cli.
@@ -267,7 +267,7 @@ def get_row_by_fullname_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -296,7 +296,7 @@ def get_row_by_fullname_command(
 def get_create_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
     create_options: list[Callable],
 ) -> Callable:
     """Return a function that creates a new row in the table
@@ -310,7 +310,7 @@ def get_create_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     create_options: list[Callable]
@@ -342,7 +342,7 @@ def get_create_command(
 def get_update_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
     update_options: list[Callable],
 ) -> Callable:
     """Return a function that updates a row in the table
@@ -356,7 +356,7 @@ def get_update_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     update_options: list[Callable]
@@ -512,7 +512,7 @@ def get_resolved_collections_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -693,7 +693,7 @@ def get_spec_aliases_command(
 def get_update_status_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that updates the status
     of row in the table and attaches that function to the cli.
@@ -706,7 +706,7 @@ def get_update_status_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -967,9 +967,6 @@ def get_action_run_check_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
-        Underlying database class
-
     Returns
     -------
     the_function: Callable
@@ -996,7 +993,7 @@ def get_action_run_check_command(
 def get_action_accept_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that marks a row in the table as accepted
     and attaches that function to the cli.
@@ -1009,7 +1006,7 @@ def get_action_accept_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -1038,7 +1035,7 @@ def get_action_accept_command(
 def get_action_reject_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that marks a row in the table as rejected
     and attaches that function to the cli.
@@ -1051,7 +1048,7 @@ def get_action_reject_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -1080,7 +1077,7 @@ def get_action_reject_command(
 def get_action_reset_command(
     group_command: Callable,
     sub_client_name: str,
-    db_class: TypeAlias,
+    db_class: type[RowMixin],
 ) -> Callable:
     """Return a function that resets the status of a row in the table
     and attaches that function to the cli.
@@ -1093,7 +1090,7 @@ def get_action_reset_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: type
         Underlying database class
 
     Returns
@@ -1125,7 +1122,7 @@ def get_action_reset_command(
 def get_element_parent_command(
     group_command: Callable,
     sub_client_name: str,
-    db_parent_class: TypeAlias,
+    db_parent_class: type[ElementMixin],
 ) -> Callable:
     """Return a function that gets the parent of an element
 
@@ -1137,7 +1134,7 @@ def get_element_parent_command(
     sub_client_name: str
         Name of python API sub-client to use
 
-    db_parent_class: TypeAlias = db.RowMixin
+    db_parent_class: type
         Underlying parent database class
 
     Returns

--- a/src/lsst/cmservice/client/script_dependencies.py
+++ b/src/lsst/cmservice/client/script_dependencies.py
@@ -50,9 +50,4 @@ class CMScriptDependencyClient:
         f"{router_string}/create",
     )
 
-    update = wrappers.update_row_function(
-        ResponseModelClass,
-        f"{router_string}/update",
-    )
-
     delete = wrappers.delete_row_function(f"{router_string}/delete")

--- a/src/lsst/cmservice/client/step_dependencies.py
+++ b/src/lsst/cmservice/client/step_dependencies.py
@@ -50,9 +50,4 @@ class CMStepDependencyClient:
         f"{router_string}/create",
     )
 
-    update = wrappers.update_row_function(
-        ResponseModelClass,
-        f"{router_string}/update",
-    )
-
     delete = wrappers.delete_row_function(f"{router_string}/delete")

--- a/src/lsst/cmservice/client/wrappers.py
+++ b/src/lsst/cmservice/client/wrappers.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from httpx import ConnectError, HTTPStatusError
-from pydantic import BaseModel, TypeAdapter
+from pydantic import TypeAdapter
 
 from .. import models
 from ..common.logging import LOGGER
@@ -17,7 +17,7 @@ logger = LOGGER.bind(module=__name__)
 
 
 def get_rows_no_parent_function(
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that gets all the rows from a table
@@ -28,7 +28,7 @@ def get_rows_no_parent_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -53,7 +53,7 @@ def get_rows_no_parent_function(
 
 
 def get_rows_function(
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:  # pragma: no cover
     """Return a function that gets all the rows from a table
@@ -66,7 +66,7 @@ def get_rows_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -99,7 +99,7 @@ def get_rows_function(
 
 
 def get_row_function(
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that gets a single row from a table (by ID)
@@ -107,7 +107,7 @@ def get_row_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -131,8 +131,8 @@ def get_row_function(
 
 
 def create_row_function(
-    response_model_class: TypeAlias = BaseModel,
-    create_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
+    create_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that creates a single row in a table
@@ -140,10 +140,10 @@ def create_row_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
-    create_model_class: TypeAlias = BaseModel,
+    create_model_class: TypeAlias,
         Pydantic class used to serialize the inputs value
 
     query: str
@@ -168,8 +168,8 @@ def create_row_function(
 
 
 def update_row_function(
-    response_model_class: TypeAlias = BaseModel,
-    update_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
+    update_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that updates a single row in a table
@@ -177,10 +177,10 @@ def update_row_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
-    update_model_class: TypeAlias = BaseModel,
+    update_model_class: TypeAlias,
         Pydantic class used to serialize the input values
 
     query: str
@@ -233,7 +233,7 @@ def delete_row_function(
 
 
 def get_row_by_fullname_function(
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that gets a single row from a table (by fullname)
@@ -241,7 +241,7 @@ def get_row_by_fullname_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -268,7 +268,7 @@ def get_row_by_fullname_function(
 
 
 def get_row_by_name_function(
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
     query: str = "",
 ) -> Callable:
     """Return a function that gets a single row from a table (by name)
@@ -276,7 +276,7 @@ def get_row_by_name_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -316,7 +316,7 @@ def get_node_property_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -353,7 +353,7 @@ def get_node_post_query_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query_class: TypeAlias
@@ -394,7 +394,7 @@ def get_node_post_no_query_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -421,7 +421,7 @@ def get_node_post_no_query_function(
 
 
 def get_general_post_function(
-    query_class: TypeAlias = BaseModel,
+    query_class: TypeAlias,
     response_model_class: TypeAlias = Any,
     query: str = "",
     results_key: str | None = None,
@@ -431,7 +431,7 @@ def get_general_post_function(
 
     Parameters
     ----------
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str
@@ -460,7 +460,7 @@ def get_general_post_function(
 
 
 def get_general_query_function(
-    query_class: TypeAlias = BaseModel,
+    query_class: TypeAlias,
     response_model_class: TypeAlias = Any,
     query: str = "",
     query_suffix: str = "",
@@ -474,7 +474,7 @@ def get_general_query_function(
     query_class: TypeAlias
         Pydantic class used to serialize the query parameters
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     query: str

--- a/src/lsst/cmservice/common/daemon.py
+++ b/src/lsst/cmservice/common/daemon.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
 
 from ..common import notification, timestamp
 from ..common.enums import StatusEnum
+from ..common.types import AnyAsyncSession
 from ..config import config
 from ..db.node import NodeMixin
 from ..db.queue import Queue
@@ -15,7 +15,7 @@ from .logging import LOGGER
 logger = LOGGER.bind(module=__name__)
 
 
-async def check_due_date(session: async_scoped_session, node: NodeMixin, time_next_check: datetime) -> None:
+async def check_due_date(session: AnyAsyncSession, node: NodeMixin, time_next_check: datetime) -> None:
     """For a provided due date, check if the queue entry is overdue"""
 
     due_date = node.metadata_.get("due_date", None)
@@ -27,7 +27,7 @@ async def check_due_date(session: async_scoped_session, node: NodeMixin, time_ne
         await notification.send_notification(for_status=StatusEnum.overdue, for_campaign=campaign)
 
 
-async def daemon_iteration(session: async_scoped_session) -> None:
+async def daemon_iteration(session: AnyAsyncSession) -> None:
     iteration_start = timestamp.now_utc()
     processed_nodes = 0
     queue_entries = await session.execute(

--- a/src/lsst/cmservice/common/errors.py
+++ b/src/lsst/cmservice/common/errors.py
@@ -1,10 +1,8 @@
 """cm-service specific error types"""
 
-from typing import Any, TypeVar
+from typing import Any
 
 from sqlalchemy.exc import IntegrityError
-
-T = TypeVar("T")
 
 
 class CMCheckError(KeyError):
@@ -123,7 +121,7 @@ class CMYamlParseError(KeyError):
     """Raised when parsing a yaml file fails"""
 
 
-def test_type_and_raise(object: Any, expected_type: type[T], var_name: str) -> T:
+def test_type_and_raise[T](object: Any, expected_type: type[T], var_name: str) -> T:
     if not isinstance(object, expected_type):
         raise CMBadParameterTypeError(f"{var_name} expected type {expected_type} got {type(object)}")
     return object

--- a/src/lsst/cmservice/common/graph.py
+++ b/src/lsst/cmservice/common/graph.py
@@ -1,18 +1,19 @@
 from collections.abc import Mapping, Sequence
-from typing import TypeVar
 
 import networkx as nx
-from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
 
 from ..db import Script, ScriptDependency, Step, StepDependency
 from ..parsing.string import parse_element_fullname
+from .types import AnyAsyncSession
 
-A = TypeVar("A", async_scoped_session, AsyncSession)
-N = TypeVar("N", type[Step], type[Script])
+type AnyGraphEdge = StepDependency | ScriptDependency
+type AnyGraphNode = Step | Script
 
 
 async def graph_from_edge_list(
-    edges: Sequence[StepDependency | ScriptDependency], node_type: N, session: A
+    edges: Sequence[AnyGraphEdge],
+    node_type: type[AnyGraphNode],
+    session: AnyAsyncSession,
 ) -> nx.DiGraph:
     """Given a sequence of edge-tuples, create a directed graph for these
     edges with nodes derived from database lookups of the related objects.

--- a/src/lsst/cmservice/common/types.py
+++ b/src/lsst/cmservice/common/types.py
@@ -2,5 +2,11 @@ from sqlalchemy.ext.asyncio import AsyncSession as AsyncSessionSA
 from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from .. import models
+
 type AnyAsyncSession = AsyncSession | AsyncSessionSA | async_scoped_session
 """A type union of async database sessions the application may use"""
+
+
+type AnyCampaignElement = models.Group | models.Campaign | models.Step | models.Job
+"""A type union of Campaign elements"""

--- a/src/lsst/cmservice/common/types.py
+++ b/src/lsst/cmservice/common/types.py
@@ -1,0 +1,6 @@
+from sqlalchemy.ext.asyncio import AsyncSession as AsyncSessionSA
+from sqlalchemy.ext.asyncio import async_scoped_session
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+type AnyAsyncSession = AsyncSession | AsyncSessionSA | async_scoped_session
+"""A type union of async database sessions the application may use"""

--- a/src/lsst/cmservice/daemon.py
+++ b/src/lsst/cmservice/daemon.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 import uvicorn
 from anyio import current_time, sleep_until
 from fastapi import FastAPI
-from safir.database import create_async_session, create_database_engine
 from safir.logging import configure_uvicorn_logging
 
 from . import __version__
@@ -15,6 +14,7 @@ from .common.daemon import daemon_iteration
 from .common.logging import LOGGER
 from .common.panda import get_panda_token
 from .config import config
+from .db.session import db_session_dependency
 from .routers.healthz import health_router
 
 configure_uvicorn_logging(config.logging.level)
@@ -31,10 +31,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     os.environ |= config.panda.model_dump(by_alias=True, exclude_none=True)
     os.environ |= config.htcondor.model_dump(by_alias=True, exclude_none=True)
     app.state.tasks = set()
+    # Dependency inits before app starts running
+    await db_session_dependency.initialize()
+    assert db_session_dependency.engine is not None
     daemon = create_task(main_loop(app=app), name="daemon")
     app.state.tasks.add(daemon)
     yield
     # stop
+    await db_session_dependency.aclose()
 
 
 async def main_loop(app: FastAPI) -> None:
@@ -43,24 +47,21 @@ async def main_loop(app: FastAPI) -> None:
     With a database session, perform a single daemon interation and then sleep
     until the next daemon appointment.
     """
-    engine = create_database_engine(config.db.url, config.db.password)
-
     sleep_time = config.daemon.processing_interval
 
-    async with engine.begin():
-        session = await create_async_session(engine, logger)
-        logger.info("Daemon starting.")
-        _iteration_count = 0
+    session = await anext(db_session_dependency())
+    logger.info("Daemon starting.")
+    _iteration_count = 0
 
-        while True:
-            _iteration_count += 1
-            logger.info("Daemon starting iteration.")
-            await daemon_iteration(session)
-            _iteration_time = current_time()
-            logger.info(f"Daemon completed {_iteration_count} iterations at {_iteration_time}.")
-            _next_wakeup = _iteration_time + sleep_time
-            logger.info(f"Daemon next iteration at {_next_wakeup}.")
-            await sleep_until(_next_wakeup)
+    while True:
+        _iteration_count += 1
+        logger.info("Daemon starting iteration.")
+        await daemon_iteration(session)
+        _iteration_time = current_time()
+        logger.info(f"Daemon completed {_iteration_count} iterations at {_iteration_time}.")
+        _next_wakeup = _iteration_time + sleep_time
+        logger.info(f"Daemon next iteration at {_next_wakeup}.")
+        await sleep_until(_next_wakeup)
 
 
 def main() -> None:

--- a/src/lsst/cmservice/db/campaign.py
+++ b/src/lsst/cmservice/db/campaign.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
@@ -22,6 +21,7 @@ from .spec_block import SpecBlock
 from .specification import Specification
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .job import Job
     from .script import Script
     from .step import Step
@@ -94,7 +94,7 @@ class Campaign(Base, ElementMixin):
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Campaign:
         """Maps self to self.get_campaign() for consistency"""
         assert session  # For mypy
@@ -105,7 +105,7 @@ class Campaign(Base, ElementMixin):
 
     async def children(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Iterable:
         """Maps self.s_ to self.children() for consistency"""
         await session.refresh(self, attribute_names=["s_"])
@@ -113,7 +113,7 @@ class Campaign(Base, ElementMixin):
 
     async def get_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedWmsTaskReportDict:
         the_dict = MergedWmsTaskReportDict(reports={})
@@ -125,7 +125,7 @@ class Campaign(Base, ElementMixin):
 
     async def get_tasks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedTaskSetDict:
         the_dict = MergedTaskSetDict(reports={})
@@ -136,7 +136,7 @@ class Campaign(Base, ElementMixin):
 
     async def get_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedProductSetDict:
         the_dict = MergedProductSetDict(reports={})
@@ -148,7 +148,7 @@ class Campaign(Base, ElementMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         name = kwargs["name"]

--- a/src/lsst/cmservice/db/campaign.py
+++ b/src/lsst/cmservice/db/campaign.py
@@ -62,7 +62,7 @@ class Campaign(Base, ElementMixin):
     metadata_: Mapped[dict] = mapped_column("metadata_", type_=MutableDict.as_mutable(JSONB), default=dict)
     child_config: Mapped[dict | list | None] = mapped_column(type_=JSON)
     collections: Mapped[dict | list | None] = mapped_column(type_=JSON)
-    spec_aliases: Mapped[dict | list | None] = mapped_column(type_=JSON)
+    spec_aliases: Mapped[dict | None] = mapped_column(type_=JSON)
 
     spec_: Mapped[Specification] = relationship(
         "Specification",

--- a/src/lsst/cmservice/db/element.py
+++ b/src/lsst/cmservice/db/element.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy.ext.asyncio import async_scoped_session
-
 from ..common.enums import LevelEnum, NodeTypeEnum, StatusEnum
 from ..common.errors import CMBadStateTransitionError, CMTooManyActiveScriptsError
 from ..config import config
@@ -14,6 +12,7 @@ from ..models.merged_wms_task_report import MergedWmsTaskReportDict
 from .node import NodeMixin
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .job import Job
     from .script import Script
 
@@ -37,7 +36,7 @@ class ElementMixin(NodeMixin):
 
     async def get_scripts(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script_name: str | None = None,
         *,
         remaining_only: bool = False,
@@ -47,7 +46,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script_name: str | None
@@ -78,7 +77,7 @@ class ElementMixin(NodeMixin):
 
     async def get_jobs(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         remaining_only: bool = False,
         skip_superseded: bool = True,
@@ -87,7 +86,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         remaining_only: bool
@@ -113,7 +112,7 @@ class ElementMixin(NodeMixin):
 
     async def get_all_scripts(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         remaining_only: bool = False,
         skip_superseded: bool = True,
@@ -122,7 +121,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         remaining_only: bool
@@ -153,7 +152,7 @@ class ElementMixin(NodeMixin):
 
     async def children(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Iterable:
         """Maps to [] for consistency"""
         assert session  # for mypy
@@ -161,7 +160,7 @@ class ElementMixin(NodeMixin):
 
     async def retry_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script_name: str,
         *,
         fake_reset: bool = True,
@@ -170,7 +169,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script_name: str
@@ -198,7 +197,7 @@ class ElementMixin(NodeMixin):
 
     async def estimate_sleep_time(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         minimum_sleep_time: int = 10,
     ) -> int:
         """Estimate how long to sleep before calling process again.
@@ -208,7 +207,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -234,14 +233,14 @@ class ElementMixin(NodeMixin):
 
     async def get_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedWmsTaskReportDict:
         """Get the WmwTaskReports associated to this element
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -253,7 +252,7 @@ class ElementMixin(NodeMixin):
 
     async def get_tasks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedTaskSetDict:
         """Get the TaskSet associated to this element
@@ -270,14 +269,14 @@ class ElementMixin(NodeMixin):
 
     async def get_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedProductSetDict:
         """Get the ProductSet associated to this element
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -289,7 +288,7 @@ class ElementMixin(NodeMixin):
 
     async def review(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> StatusEnum:
         """Run review() function on this Element
@@ -298,7 +297,7 @@ class ElementMixin(NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns

--- a/src/lsst/cmservice/db/group.py
+++ b/src/lsst/cmservice/db/group.py
@@ -61,7 +61,7 @@ class Group(Base, ElementMixin):
     metadata_: Mapped[dict] = mapped_column("metadata_", type_=MutableDict.as_mutable(JSONB), default=dict)
     child_config: Mapped[dict | list | None] = mapped_column(type_=JSON)
     collections: Mapped[dict | list | None] = mapped_column(type_=JSON)
-    spec_aliases: Mapped[dict | list | None] = mapped_column(type_=JSON)
+    spec_aliases: Mapped[dict | None] = mapped_column(type_=JSON)
 
     spec_block_: Mapped[SpecBlock] = relationship("SpecBlock", viewonly=True)
     c_: Mapped["Campaign"] = relationship(

--- a/src/lsst/cmservice/db/group.py
+++ b/src/lsst/cmservice/db/group.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey, UniqueConstraint
@@ -18,6 +17,7 @@ from ..common.errors import (
     CMTooFewAcceptedJobsError,
     CMTooManyActiveScriptsError,
 )
+from ..common.types import AnyAsyncSession
 from ..models.merged_product_set import MergedProductSetDict
 from ..models.merged_task_set import MergedTaskSetDict
 from ..models.merged_wms_task_report import MergedWmsTaskReportDict
@@ -85,7 +85,7 @@ class Group(Base, ElementMixin):
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> "Campaign":
         """Maps self.c_ to self.get_campaign() for consistency"""
         await session.refresh(self, attribute_names=["c_"])
@@ -96,7 +96,7 @@ class Group(Base, ElementMixin):
 
     async def children(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Iterable:
         """Maps self.g_ to self.children() for consistency"""
         await session.refresh(self, attribute_names=["jobs_"])
@@ -104,7 +104,7 @@ class Group(Base, ElementMixin):
 
     async def get_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedWmsTaskReportDict:
         the_dict = MergedWmsTaskReportDict(reports={})
@@ -116,7 +116,7 @@ class Group(Base, ElementMixin):
 
     async def get_tasks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedTaskSetDict:
         the_dict = MergedTaskSetDict(reports={})
@@ -127,7 +127,7 @@ class Group(Base, ElementMixin):
 
     async def get_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedProductSetDict:
         the_dict = MergedProductSetDict(reports={})
@@ -139,7 +139,7 @@ class Group(Base, ElementMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         try:
@@ -175,7 +175,7 @@ class Group(Base, ElementMixin):
 
     async def rescue_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> "Job":
         """Create a rescue `Job`
 
@@ -183,7 +183,7 @@ class Group(Base, ElementMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -208,13 +208,13 @@ class Group(Base, ElementMixin):
 
     async def mark_job_rescued(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> list["Job"]:
         """Mark jobs as `rescued` once one of their siblings is `accepted`
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns

--- a/src/lsst/cmservice/db/handler.py
+++ b/src/lsst/cmservice/db/handler.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import types
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from sqlalchemy.ext.asyncio import async_scoped_session
-
 from lsst.utils import doImport
 from lsst.utils.introspection import get_full_type_name
 
@@ -13,6 +11,7 @@ from ..common.errors import CMBadHandlerTypeError
 from ..common.logging import LOGGER
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .element import ElementMixin
     from .node import NodeMixin
     from .script import Script
@@ -93,7 +92,7 @@ class Handler:
 
     async def process(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -101,7 +100,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         node: NodeMixin
@@ -121,7 +120,7 @@ class Handler:
 
     async def run_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -129,7 +128,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         node: NodeMixin
@@ -149,7 +148,7 @@ class Handler:
 
     async def reset(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         to_status: StatusEnum,
         *,
@@ -159,7 +158,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         node: NodeMixin
@@ -180,7 +179,7 @@ class Handler:
 
     async def reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         to_status: StatusEnum,
         *,
@@ -190,7 +189,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         node: NodeMixin
@@ -211,7 +210,7 @@ class Handler:
 
     async def review(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> StatusEnum:
@@ -219,7 +218,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         element: ElementMixin
@@ -234,7 +233,7 @@ class Handler:
 
     async def review_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -243,7 +242,7 @@ class Handler:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         script: Script

--- a/src/lsst/cmservice/db/job.py
+++ b/src/lsst/cmservice/db/job.py
@@ -68,7 +68,7 @@ class Job(Base, ElementMixin):
     )
     child_config: Mapped[dict | list | None] = mapped_column(type_=JSON)
     collections: Mapped[dict | list | None] = mapped_column(type_=JSON)
-    spec_aliases: Mapped[dict | list | None] = mapped_column(type_=JSON)
+    spec_aliases: Mapped[dict | None] = mapped_column(type_=JSON)
     wms_job_id: Mapped[str | None] = mapped_column()
     stamp_url: Mapped[str | None] = mapped_column()
 

--- a/src/lsst/cmservice/db/job.py
+++ b/src/lsst/cmservice/db/job.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import JSON, and_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
@@ -27,6 +26,7 @@ from .group import Group
 from .step import Step
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .campaign import Campaign
     from .pipetask_error import PipetaskError
     from .product_set import ProductSet
@@ -118,7 +118,7 @@ class Job(Base, ElementMixin):
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Campaign:
         """Maps self.c_ to self.get_campaign() for consistency"""
         await session.refresh(self, attribute_names=["c_"])
@@ -126,13 +126,13 @@ class Job(Base, ElementMixin):
 
     async def get_siblings(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Sequence[Job]:
         """Get the sibling Jobs
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -152,7 +152,7 @@ class Job(Base, ElementMixin):
 
     async def get_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedWmsTaskReportDict:
         await session.refresh(self, attribute_names=["wms_reports_"])
@@ -163,7 +163,7 @@ class Job(Base, ElementMixin):
 
     async def get_tasks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedTaskSetDict:
         await session.refresh(self, attribute_names=["tasks_"])
@@ -172,7 +172,7 @@ class Job(Base, ElementMixin):
 
     async def get_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedProductSetDict:
         await session.refresh(self, attribute_names=["products_"])
@@ -181,7 +181,7 @@ class Job(Base, ElementMixin):
 
     async def get_errors(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Sequence[PipetaskError]:
         await session.refresh(self, attribute_names=["errors_"])
         return self.errors_
@@ -192,7 +192,7 @@ class Job(Base, ElementMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         try:
@@ -230,14 +230,14 @@ class Job(Base, ElementMixin):
 
     async def copy_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         parent: ElementMixin,
     ) -> Job:
         """Copy a Job
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         parent : ElementMixin
@@ -298,7 +298,7 @@ class Job(Base, ElementMixin):
 
     async def get_jobs(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         remaining_only: bool = False,
         skip_superseded: bool = True,

--- a/src/lsst/cmservice/db/node.py
+++ b/src/lsst/cmservice/db/node.py
@@ -5,7 +5,6 @@ from collections import ChainMap, defaultdict
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.orm.collections import InstrumentedList
 
 from ..common import timestamp
@@ -27,6 +26,7 @@ from .spec_block import SpecBlock
 from .specification import Specification
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .campaign import Campaign
     from .element import ElementMixin
 
@@ -60,13 +60,13 @@ class NodeMixin(RowMixin):
 
     async def get_spec_block(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> SpecBlock:
         """Get the `SpecBlock` object associated to a particular row
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -81,13 +81,13 @@ class NodeMixin(RowMixin):
 
     async def get_specification(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Specification:
         """Get the `Specification` object associated to a particular row
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -101,13 +101,13 @@ class NodeMixin(RowMixin):
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Campaign:
         """Get the parent `Campaign`
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -119,13 +119,13 @@ class NodeMixin(RowMixin):
 
     async def get_parent(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> ElementMixin:
         """Get the parent `Element`
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -140,7 +140,7 @@ class NodeMixin(RowMixin):
 
     async def get_handler(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Handler:
         """Get the Handler object associated with a particular row
 
@@ -149,7 +149,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -167,7 +167,7 @@ class NodeMixin(RowMixin):
 
     async def resolve_collections(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         throw_overrides: bool = True,
     ) -> dict:
@@ -181,7 +181,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         throw_overrides : bool
@@ -221,7 +221,7 @@ class NodeMixin(RowMixin):
 
     async def get_collections(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> dict:
         """Get the collection configuration associated with a particular row.
 
@@ -230,7 +230,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -262,7 +262,7 @@ class NodeMixin(RowMixin):
 
     async def get_child_config(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> dict:
         """Get the child configuration associated with a particular row.
 
@@ -271,7 +271,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -291,7 +291,7 @@ class NodeMixin(RowMixin):
 
     async def data_dict(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> dict:
         """Get the data configuration associated to a particular row
 
@@ -300,7 +300,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -326,7 +326,7 @@ class NodeMixin(RowMixin):
 
     async def get_spec_aliases(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> dict:
         """Get the spec_aliases associated with a particular node
 
@@ -335,7 +335,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -359,14 +359,14 @@ class NodeMixin(RowMixin):
 
     async def update_child_config(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> NodeMixin:
         """Update the child configuration associated with this Node
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         kwargs: Any
@@ -402,7 +402,7 @@ class NodeMixin(RowMixin):
 
     async def update_collections(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         force: bool = False,
         **kwargs: Any,
@@ -411,7 +411,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         kwargs: Any
@@ -446,14 +446,14 @@ class NodeMixin(RowMixin):
 
     async def update_spec_aliases(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> NodeMixin:
         """Update the spec_alisases configuration associated with this Node
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         kwargs: Any
@@ -489,7 +489,7 @@ class NodeMixin(RowMixin):
 
     async def update_metadata_dict(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> NodeMixin:
         """Update the metadata configuration associated with this Node.
@@ -499,7 +499,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         kwargs: Any
@@ -534,7 +534,7 @@ class NodeMixin(RowMixin):
 
     async def update_data_dict(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> NodeMixin:
         """Update the data configuration associated with this Node.
@@ -544,7 +544,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         kwargs: Any
@@ -601,14 +601,14 @@ class NodeMixin(RowMixin):
 
     async def check_prerequisites(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> bool:
         """Check if the prerequisties for processing a particular node are
         completed.
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -628,13 +628,13 @@ class NodeMixin(RowMixin):
 
     async def reject(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> NodeMixin:
         """Set a node as rejected
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -656,13 +656,13 @@ class NodeMixin(RowMixin):
 
     async def accept(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> NodeMixin:
         """Set a node as accepted
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -690,7 +690,7 @@ class NodeMixin(RowMixin):
 
     async def reset(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         fake_reset: bool = False,
     ) -> NodeMixin:
@@ -698,7 +698,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         fake_reset: bool
@@ -718,7 +718,7 @@ class NodeMixin(RowMixin):
 
     async def _clean_up_node(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         *,
         fake_reset: bool = False,
     ) -> NodeMixin:
@@ -726,7 +726,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         fake_reset: bool
@@ -741,7 +741,7 @@ class NodeMixin(RowMixin):
 
     async def process(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
         """Process this `Node` as much as possible
@@ -750,7 +750,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -766,7 +766,7 @@ class NodeMixin(RowMixin):
 
     async def run_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
         """Check on this Nodes's status
@@ -775,7 +775,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -790,7 +790,7 @@ class NodeMixin(RowMixin):
 
     async def estimate_sleep_time(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         minimum_sleep_time: int = 10,
     ) -> int:
         """Estimate how long to sleep before calling process again.
@@ -800,7 +800,7 @@ class NodeMixin(RowMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -815,7 +815,7 @@ class NodeMixin(RowMixin):
 
     async def update_mtime(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> None:
         """Update the mtime attribute in an element's hierarchy."""
         mtime = timestamp.element_time()

--- a/src/lsst/cmservice/db/queue.py
+++ b/src/lsst/cmservice/db/queue.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON, and_, select
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
@@ -21,6 +20,10 @@ from .job import Job
 from .node import NodeMixin
 from .script import Script
 from .step import Step
+
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
 
 logger = LOGGER.bind(module=__name__)
 
@@ -71,13 +74,13 @@ class Queue(Base, NodeMixin):
 
     async def get_node(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> NodeMixin:
         """Get the parent `Node`
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -108,14 +111,14 @@ class Queue(Base, NodeMixin):
     @classmethod
     async def get_queue_item(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> Queue:
         """Get the queue row corresponding to a partiuclar node
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
         Keywords
         --------
@@ -157,7 +160,7 @@ class Queue(Base, NodeMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         fullname = kwargs["fullname"]
@@ -200,7 +203,7 @@ class Queue(Base, NodeMixin):
 
     async def node_sleep_time(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> int:
         """Check how long to sleep based on what is running"""
         node = await self.get_node(session)
@@ -224,7 +227,7 @@ class Queue(Base, NodeMixin):
 
     async def process_node(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> bool:  # pragma: no cover
         """Process associated node and update queue row"""
         node = await self.get_node(session)

--- a/src/lsst/cmservice/db/row.py
+++ b/src/lsst/cmservice/db/row.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
 
 from ..common.enums import StatusEnum
 from ..common.errors import (
@@ -21,8 +20,7 @@ logger = LOGGER.bind(module=__name__)
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    T = TypeVar("T", bound="RowMixin")
-    A = TypeVar("A", AsyncSession, async_scoped_session)
+    from ..common.types import AnyAsyncSession
 
 DELETABLE_STATES = [
     StatusEnum.failed,
@@ -38,23 +36,23 @@ class RowMixin:
     Defines an interface to manipulate any sort of table.
     """
 
-    id: Any  # Primary Key, typically an int
-    name: Any  # Human-readable name for row
     fullname: Any  # Human-readable unique name for row
-
+    id: Any  # Primary Key, typically an int
     class_string: str  # Name to use for help functions and descriptions
+    col_names_for_table: list
+    name: Any  # Human-readable name for row
 
     @classmethod
-    async def get_rows(
+    async def get_rows[T: RowMixin](
         cls: type[T],
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> Sequence[T]:
         """Get rows associated to a particular table
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         Keywords
@@ -109,16 +107,16 @@ class RowMixin:
         return results.all()
 
     @classmethod
-    async def get_row(
+    async def get_row[T: RowMixin](
         cls: type[T],
-        session: A,
+        session: AnyAsyncSession,
         row_id: int,
     ) -> T:
         """Get a single row, matching row.id == row_id
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         row_id: int
@@ -135,16 +133,16 @@ class RowMixin:
         return result
 
     @classmethod
-    async def get_row_by_name(
+    async def get_row_by_name[T: RowMixin](
         cls: type[T],
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         name: str,
     ) -> T:
         """Get a single row, with row.name == name
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         name : str
@@ -163,16 +161,16 @@ class RowMixin:
         return row
 
     @classmethod
-    async def get_row_by_fullname(
+    async def get_row_by_fullname[T: RowMixin](
         cls: type[T],
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         fullname: str,
     ) -> T:
         """Get a single row, with row.fullname == fullname
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         fullname : str
@@ -193,14 +191,14 @@ class RowMixin:
     @classmethod
     async def delete_row(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         row_id: int,
     ) -> None:
         """Delete a single row, matching row.id == row_id
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         row_id: int
@@ -231,14 +229,14 @@ class RowMixin:
     @classmethod
     async def _delete_hook(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         row_id: int,
     ) -> None:
         """Hook called during delete_row
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         row_id: int
@@ -250,9 +248,9 @@ class RowMixin:
         return
 
     @classmethod
-    async def update_row(
+    async def update_row[T: RowMixin](
         cls: type[T],
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         row_id: int,
         **kwargs: Any,
     ) -> T:
@@ -260,7 +258,7 @@ class RowMixin:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         row_id: int
@@ -311,16 +309,16 @@ class RowMixin:
         return row
 
     @classmethod
-    async def create_row(
+    async def create_row[T: RowMixin](
         cls: type[T],
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> T:
         """Create a single row
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         kwargs: Any
@@ -346,8 +344,8 @@ class RowMixin:
 
     @classmethod
     async def get_create_kwargs(
-        cls: type[T],
-        session: async_scoped_session,
+        cls,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         """Get additional keywords needed to create a row
@@ -358,7 +356,7 @@ class RowMixin:
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         kwargs: Any
@@ -371,16 +369,16 @@ class RowMixin:
         """
         return kwargs
 
-    async def update_values(
+    async def update_values[T: RowMixin](
         self: T,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> T:
         """Update values in a row
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : A
             DB session manager
 
         kwargs: Any

--- a/src/lsst/cmservice/db/script.py
+++ b/src/lsst/cmservice/db/script.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
@@ -25,6 +24,7 @@ from .spec_block import SpecBlock
 from .step import Step
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .script_error import ScriptError
 
 
@@ -111,14 +111,14 @@ class Script(Base, NodeMixin):
 
     async def get_script_errors(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> list[ScriptError]:
         await session.refresh(self, attribute_names=["errors_"])
         return self.errors_
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Campaign:
         """Maps self.get_parent().c_ to self.get_campaign() for consistency"""
         parent = await self.get_parent(session)
@@ -131,13 +131,13 @@ class Script(Base, NodeMixin):
 
     async def get_parent(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> ElementMixin:
         """Get the parent `Element`
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns
@@ -165,7 +165,7 @@ class Script(Base, NodeMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         try:
@@ -229,7 +229,7 @@ class Script(Base, NodeMixin):
 
     async def reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         to_status: StatusEnum,
         *,
         fake_reset: bool = False,
@@ -243,7 +243,7 @@ class Script(Base, NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         to_status : StatusEnum
@@ -262,7 +262,7 @@ class Script(Base, NodeMixin):
 
     async def review(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> StatusEnum:
         """Run review() function on this Script
@@ -272,7 +272,7 @@ class Script(Base, NodeMixin):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns

--- a/src/lsst/cmservice/db/script_dependency.py
+++ b/src/lsst/cmservice/db/script_dependency.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy.dialects.postgresql as sapg
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
 
@@ -13,6 +12,7 @@ from .base import Base
 from .row import RowMixin
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .script import Script
 
 
@@ -41,13 +41,13 @@ class ScriptDependency(Base, RowMixin):
 
     async def is_done(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> bool:
         """Check if this dependency is completed
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns

--- a/src/lsst/cmservice/db/session.py
+++ b/src/lsst/cmservice/db/session.py
@@ -1,9 +1,93 @@
 """Module to create and handle async database sessions"""
 
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
+from collections.abc import AsyncGenerator
+
+# from pydantic import SecretStr  #noqa: ERA001
+from sqlalchemy import make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from ..config import config
 
 
-async def get_async_scoped_session() -> async_scoped_session:
-    """Provides an async session from the safir session maker."""
+class DatabaseSessionDependency:
+    """A database session manager class designed to manage an async sqlalchemy
+    engine and produce sessions.
+
+    A module-level instance of this class is created, and when called, a new
+    async session is yielded.
+    """
+
+    def __init__(self) -> None:
+        self.engine: AsyncEngine | None = None
+        self.sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+    async def initialize(
+        self,
+        *,
+        isolation_level: str | None = None,
+        use_async: bool = True,
+        echo: bool = False,
+    ) -> None:
+        """Initialize the session dependency.
+
+        Parameters
+        ----------
+        url
+            Database connection URL, not including the password.
+        password
+            Database connection password.
+        isolation_level
+            If specified, sets a non-default isolation level for the database
+            engine.
+        use_async
+            If true (default), the database drivername will be forced to an
+            async form.
+        """
+        if isinstance(config.db.url, str):
+            url = make_url(config.db.url)
+        if use_async and url.drivername == "postgresql":
+            url = url.set(drivername="postgresql+asyncpg")
+        # FIXME use SecretStr for password
+        # if isinstance(config.db.password, SecretStr):
+        #     password = config.db.password.get_secret_value()  #noqa: ERA001
+        if config.db.password is not None:
+            url = url.set(password=config.db.password)
+        if self.engine:
+            await self.engine.dispose()
+        self.engine = create_async_engine(
+            url=url,
+            echo=config.db.echo,
+            # TODO add pool-level configs
+        )
+        self.sessionmaker = async_sessionmaker(self.engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def __call__(self) -> AsyncGenerator[AsyncSession]:
+        """Yields a database session.
+
+        Yields
+        -------
+        sqlmodel.ext.asyncio.AsyncSession
+            The newly-created session.
+        """
+        if not self.sessionmaker:
+            raise RuntimeError("Async sessionmaker is not initialized")
+
+        async with self.sessionmaker() as session:
+            yield session
+
+    async def aclose(self) -> None:
+        """Shut down the database engine."""
+        if self.engine:
+            self.sessionmaker = None
+            await self.engine.dispose()
+            self._engine = None
+
+
+db_session_dependency = DatabaseSessionDependency()
+"""A module-level instance of the session manager"""
+
+
+# FIXME not sure why this pattern
+async def get_async_session() -> AsyncSession:
     return await anext(db_session_dependency())

--- a/src/lsst/cmservice/db/spec_block.py
+++ b/src/lsst/cmservice/db/spec_block.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 from .handler import Handler
 from .row import RowMixin
+
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
 
 
 class SpecBlock(Base, RowMixin):
@@ -45,7 +47,7 @@ class SpecBlock(Base, RowMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         handler = kwargs["handler"]
@@ -64,7 +66,7 @@ class SpecBlock(Base, RowMixin):
     @classmethod
     async def _delete_hook(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         row_id: int,
     ) -> None:
         Handler.remove_from_cache(row_id)

--- a/src/lsst/cmservice/db/specification.py
+++ b/src/lsst/cmservice/db/specification.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import JSON
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -9,6 +10,9 @@ from ..common.errors import CMMissingFullnameError, CMSpecificationError
 from .base import Base
 from .row import RowMixin
 from .spec_block import SpecBlock
+
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
 
 
 class Specification(Base, RowMixin):
@@ -38,14 +42,14 @@ class Specification(Base, RowMixin):
 
     async def get_block(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         spec_block_name: str,
     ) -> SpecBlock:
         """Get a SpecBlock associated to this Specification
 
         Parameters
         ----------
-        session: async_scoped_session
+        session: AnyAsyncSession
             DB session manager
 
         spec_block_name: str

--- a/src/lsst/cmservice/db/specification.py
+++ b/src/lsst/cmservice/db/specification.py
@@ -28,7 +28,7 @@ class Specification(Base, RowMixin):
     data: Mapped[dict] = mapped_column(type_=JSON, default=dict)
     child_config: Mapped[dict | list | None] = mapped_column(type_=JSON)
     collections: Mapped[dict | list | None] = mapped_column(type_=JSON)
-    spec_aliases: Mapped[dict | list | None] = mapped_column(type_=JSON)
+    spec_aliases: Mapped[dict | None] = mapped_column(type_=JSON)
 
     col_names_for_table = ["id", "name"]
 

--- a/src/lsst/cmservice/db/step.py
+++ b/src/lsst/cmservice/db/step.py
@@ -58,7 +58,7 @@ class Step(Base, ElementMixin):
     metadata_: Mapped[dict] = mapped_column("metadata_", type_=MutableDict.as_mutable(JSONB), default=dict)
     child_config: Mapped[dict | list | None] = mapped_column(type_=JSON)
     collections: Mapped[dict | list | None] = mapped_column(type_=JSON)
-    spec_aliases: Mapped[dict | list | None] = mapped_column(type_=JSON)
+    spec_aliases: Mapped[dict | None] = mapped_column(type_=JSON)
 
     spec_block_: Mapped[SpecBlock] = relationship("SpecBlock", viewonly=True)
     parent_: Mapped[Campaign] = relationship("Campaign", back_populates="s_")

--- a/src/lsst/cmservice/db/step.py
+++ b/src/lsst/cmservice/db/step.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey, UniqueConstraint
@@ -22,6 +21,7 @@ from .element import ElementMixin
 from .spec_block import SpecBlock
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .group import Group
     from .job import Job
     from .script import Script
@@ -94,7 +94,7 @@ class Step(Base, ElementMixin):
 
     async def get_campaign(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Campaign:
         """Maps self.c_ to self.get_campaign() for consistency"""
         await session.refresh(self, attribute_names=["parent_"])
@@ -102,7 +102,7 @@ class Step(Base, ElementMixin):
 
     async def children(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> Iterable:
         """Maps self.g_ to self.children() for consistency"""
         await session.refresh(self, attribute_names=["g_"])
@@ -110,7 +110,7 @@ class Step(Base, ElementMixin):
 
     async def get_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedWmsTaskReportDict:
         the_dict = MergedWmsTaskReportDict(reports={})
@@ -122,7 +122,7 @@ class Step(Base, ElementMixin):
 
     async def get_tasks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedTaskSetDict:
         the_dict = MergedTaskSetDict(reports={})
@@ -133,7 +133,7 @@ class Step(Base, ElementMixin):
 
     async def get_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> MergedProductSetDict:
         the_dict = MergedProductSetDict(reports={})
@@ -144,7 +144,7 @@ class Step(Base, ElementMixin):
 
     async def get_all_prereqs(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> list[Step]:
         all_prereqs: list[Step] = []
         await session.refresh(self, attribute_names=["prereqs_"])
@@ -158,7 +158,7 @@ class Step(Base, ElementMixin):
     @classmethod
     async def get_create_kwargs(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         **kwargs: Any,
     ) -> dict:
         try:

--- a/src/lsst/cmservice/db/step_dependency.py
+++ b/src/lsst/cmservice/db/step_dependency.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy.dialects.postgresql as sapg
-from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
 
@@ -13,6 +12,7 @@ from .base import Base
 from .row import RowMixin
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from .step import Step
 
 
@@ -41,13 +41,13 @@ class StepDependency(Base, RowMixin):
 
     async def is_done(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
     ) -> bool:
         """Check if this dependency is completed
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         Returns

--- a/src/lsst/cmservice/handlers/element_handler.py
+++ b/src/lsst/cmservice/handlers/element_handler.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid5
 
-from sqlalchemy.ext.asyncio import async_scoped_session
-
 from ..common.enums import LevelEnum, StatusEnum
 from ..common.errors import CMYamlParseError, test_type_and_raise
 from ..common.notification import send_notification
@@ -18,6 +16,9 @@ from ..db.script import Script
 from ..db.script_dependency import ScriptDependency
 from .functions import render_campaign_steps
 
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
 
 class ElementHandler(Handler):
     """SubClass of Handler to deal with generic 'Element' operations,
@@ -26,7 +27,7 @@ class ElementHandler(Handler):
 
     @staticmethod
     async def _add_prerequisite(
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script_id: int,
         prereq_id: int,
         namespace: UUID | None = None,
@@ -35,7 +36,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script_id: int
@@ -59,7 +60,7 @@ class ElementHandler(Handler):
 
     async def process(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -67,7 +68,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         node: NodeMixin
@@ -116,7 +117,7 @@ class ElementHandler(Handler):
 
     async def run_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -126,7 +127,7 @@ class ElementHandler(Handler):
 
     async def prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
     ) -> tuple[bool, StatusEnum]:
         """Prepare `Element` for processing
@@ -135,7 +136,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -218,7 +219,7 @@ class ElementHandler(Handler):
 
     async def continue_processing(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -228,7 +229,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -253,7 +254,7 @@ class ElementHandler(Handler):
 
     async def review(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> StatusEnum:
@@ -265,7 +266,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -282,7 +283,7 @@ class ElementHandler(Handler):
 
     async def _run_script_checks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> bool:
@@ -290,7 +291,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -320,7 +321,7 @@ class ElementHandler(Handler):
 
     async def _run_job_checks(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> bool:
@@ -328,7 +329,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -357,7 +358,7 @@ class ElementHandler(Handler):
 
     async def check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -366,7 +367,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -424,7 +425,7 @@ class ElementHandler(Handler):
 
     async def _post_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> StatusEnum:
@@ -432,7 +433,7 @@ class ElementHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin
@@ -451,7 +452,7 @@ class CampaignHandler(ElementHandler):
 
     async def prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
     ) -> tuple[bool, StatusEnum]:
         if TYPE_CHECKING:
@@ -466,7 +467,7 @@ class CampaignHandler(ElementHandler):
 
     async def _post_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> StatusEnum:
@@ -474,7 +475,7 @@ class CampaignHandler(ElementHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         element: ElementMixin

--- a/src/lsst/cmservice/handlers/elements.py
+++ b/src/lsst/cmservice/handlers/elements.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from anyio import to_thread
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from ..common.butler import BUTLER_FACTORY
 from ..common.enums import StatusEnum
@@ -20,6 +19,10 @@ from ..db.job import Job
 from ..db.script import Script
 from .script_handler import FunctionHandler
 
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
+
 logger = LOGGER.bind(module=__name__)
 
 
@@ -32,7 +35,7 @@ class RunElementScriptHandler(FunctionHandler):
 
     async def _do_run(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -49,7 +52,7 @@ class RunElementScriptHandler(FunctionHandler):
 
     async def _do_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -78,7 +81,7 @@ class RunJobsScriptHandler(RunElementScriptHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -102,7 +105,7 @@ class RunJobsScriptHandler(RunElementScriptHandler):
 
     async def review_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -126,7 +129,7 @@ class Splitter:
     @classmethod
     async def split(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -135,7 +138,7 @@ class Splitter:
 
         Parameters
         ----------
-        session: async_scoped_session
+        session: AnyAsyncSession
             DB session manager
 
         script: Script
@@ -157,7 +160,7 @@ class NoSplit(Splitter):
     @classmethod
     async def split(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -177,7 +180,7 @@ class SplitByVals(Splitter):
     @classmethod
     async def split(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -203,7 +206,7 @@ class SplitByQuery(Splitter):
     @classmethod
     async def split(
         cls,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -281,7 +284,7 @@ class RunGroupsScriptHandler(RunElementScriptHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -320,7 +323,7 @@ class RunStepsScriptHandler(RunElementScriptHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,

--- a/src/lsst/cmservice/handlers/functions.py
+++ b/src/lsst/cmservice/handlers/functions.py
@@ -9,7 +9,6 @@ import yaml
 from anyio import Path
 from pydantic.v1.utils import deep_update
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from lsst.ctrl.bps.bps_reports import compile_job_summary
 from lsst.ctrl.bps.wms_service import WmsRunReport, WmsStates
@@ -17,6 +16,7 @@ from lsst.ctrl.bps.wms_service import WmsRunReport, WmsStates
 from ..common.enums import DEFAULT_NAMESPACE, StatusEnum
 from ..common.errors import CMMissingFullnameError, CMYamlParseError
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
 from ..config import config
 from ..db.campaign import Campaign
 from ..db.element import ElementMixin
@@ -24,7 +24,7 @@ from ..db.job import Job
 from ..db.pipetask_error import PipetaskError
 from ..db.pipetask_error_type import PipetaskErrorType
 from ..db.product_set import ProductSet
-from ..db.session import get_async_scoped_session
+from ..db.session import get_async_session
 from ..db.spec_block import SpecBlock
 from ..db.specification import Specification
 from ..db.step import Step
@@ -36,7 +36,7 @@ logger = LOGGER.bind(module=__name__)
 
 
 async def upsert_spec_block(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     config_values: dict,
     loaded_specs: dict,
     *,
@@ -48,7 +48,7 @@ async def upsert_spec_block(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     config_values: dict
@@ -127,7 +127,7 @@ async def upsert_spec_block(
 
 
 async def upsert_specification(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     config_values: dict,
     *,
     allow_update: bool = False,
@@ -138,7 +138,7 @@ async def upsert_specification(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     config_values: dict
@@ -166,7 +166,7 @@ async def upsert_specification(
 
 
 async def load_specification(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     yaml_file: str | Path | deque,
     loaded_specs: dict | None = None,
     *,
@@ -178,7 +178,7 @@ async def load_specification(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     yaml_file: str | anyio.Path
@@ -259,13 +259,13 @@ async def load_specification(
 
 
 async def add_step_prerequisite(
-    session: async_scoped_session, depend_id: int, prereq_id: int, namespace: UUID | None = None
+    session: AnyAsyncSession, depend_id: int, prereq_id: int, namespace: UUID | None = None
 ) -> StepDependency:
     """Create and return a StepDependency
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     depend_id: int
@@ -288,7 +288,7 @@ async def add_step_prerequisite(
 
 
 async def add_steps(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     campaign: Campaign,
     step_config_list: list[dict[str, dict]] | None,
 ) -> Campaign:
@@ -296,7 +296,7 @@ async def add_steps(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     campaign: Campaign
@@ -386,14 +386,14 @@ async def force_accept_node(
     node: int,
     db_class: type[ElementMixin],
     output_collection: str | None = None,
-    session: async_scoped_session | None = None,
+    session: AnyAsyncSession | None = None,
 ) -> None:
     """Force accept a node by bypassing state transition checks and setting
     node and node's scripts to accepted.
     """
     local_session = False
     if session is None:
-        session = await get_async_scoped_session()
+        session = await get_async_session()
         local_session = True
 
     the_node = await db_class.get_row(session, node)
@@ -431,7 +431,7 @@ async def force_accept_node(
 
 async def render_campaign_steps(
     campaign: Campaign | int,
-    session: async_scoped_session | None = None,
+    session: AnyAsyncSession | None = None,
 ) -> None:
     """Render the steps for a campaign.
 
@@ -444,7 +444,7 @@ async def render_campaign_steps(
     """
     local_session = False
     if session is None:
-        session = await get_async_scoped_session()
+        session = await get_async_session()
         local_session = True
     if isinstance(campaign, int):
         campaign = await Campaign.get_row(session, campaign)
@@ -466,7 +466,7 @@ async def render_campaign_steps(
 
 
 async def match_pipetask_error(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     task_name: str,
     diagnostic_message: str,
 ) -> PipetaskErrorType | None:
@@ -474,7 +474,7 @@ async def match_pipetask_error(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     task_name: str
@@ -495,7 +495,7 @@ async def match_pipetask_error(
 
 
 async def load_manifest_report(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     job_name: str,
     yaml_file: str | Path,
     fake_status: StatusEnum | None = None,
@@ -506,7 +506,7 @@ async def load_manifest_report(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     job_name: str
@@ -715,7 +715,7 @@ def status_from_bps_report(
 
 
 async def load_wms_reports(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     job: Job,
     wms_run_report: WmsRunReport | None,
 ) -> Job:  # pragma: no cover
@@ -725,7 +725,7 @@ async def load_wms_reports(
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     job_name: str
@@ -764,14 +764,14 @@ async def load_wms_reports(
 
 
 async def load_error_types(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     yaml_file: str | Path,
 ) -> list[PipetaskErrorType]:
     """Parse and load error types
 
     Parameters
     ----------
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     yaml_file: str | anyio.Path
@@ -810,7 +810,7 @@ async def load_error_types(
 
 
 async def compute_job_status(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     job: Job,
 ) -> StatusEnum:
     await session.refresh(

--- a/src/lsst/cmservice/handlers/interface.py
+++ b/src/lsst/cmservice/handlers/interface.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db
 from ..common.enums import LevelEnum, NodeTypeEnum, StatusEnum, TableEnum
@@ -13,6 +12,7 @@ from ..common.errors import (
     test_type_and_raise,
 )
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
 from . import functions
 
 TABLE_DICT: dict[TableEnum, type[db.RowMixin]] = {
@@ -64,7 +64,7 @@ def get_table(
 
 
 async def get_row_by_table_and_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     row_id: int,
     table_enum: TableEnum,
 ) -> db.RowMixin:
@@ -72,7 +72,7 @@ async def get_row_by_table_and_id(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     row_id: int
@@ -105,7 +105,7 @@ async def get_row_by_table_and_id(
 
 
 async def get_node_by_level_and_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     element_id: int,
     level: LevelEnum,
 ) -> db.NodeMixin:
@@ -113,7 +113,7 @@ async def get_node_by_level_and_id(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     element_id: int
@@ -164,14 +164,14 @@ def get_node_type_by_fullname(
 
 
 async def get_element_by_fullname(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
 ) -> db.ElementMixin:
     """Get a `Element` from the DB
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -208,14 +208,14 @@ async def get_element_by_fullname(
 
 
 async def get_node_by_fullname(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
 ) -> db.NodeMixin:
     """Get a `Node` from the DB
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -241,7 +241,7 @@ async def get_node_by_fullname(
 
 
 async def process_script(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
     fake_status: StatusEnum | None = None,
 ) -> tuple[bool, StatusEnum]:
@@ -249,7 +249,7 @@ async def process_script(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -276,7 +276,7 @@ async def process_script(
 
 
 async def process_element(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
     fake_status: StatusEnum | None = None,
 ) -> tuple[bool, StatusEnum]:
@@ -284,7 +284,7 @@ async def process_element(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -313,7 +313,7 @@ async def process_element(
 
 
 async def process(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
     fake_status: StatusEnum | None = None,
 ) -> tuple[bool, StatusEnum]:
@@ -321,7 +321,7 @@ async def process(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -356,7 +356,7 @@ async def process(
 
 
 async def reset_script(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
     status: StatusEnum,
     *,
@@ -374,7 +374,7 @@ async def reset_script(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -403,7 +403,7 @@ async def reset_script(
 
 
 async def rescue_job(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
 ) -> db.Job:
     """Run a rescue on a `Job`
@@ -414,7 +414,7 @@ async def rescue_job(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -441,7 +441,7 @@ async def rescue_job(
 
 
 async def mark_job_rescued(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
 ) -> list[db.Job]:
     """Mark a `Job` as rescued
@@ -452,7 +452,7 @@ async def mark_job_rescued(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -481,14 +481,14 @@ async def mark_job_rescued(
 
 
 async def create_campaign(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     **kwargs: Any,
 ) -> db.Campaign:
     """Create a new Campaign
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     kwargs : Any
@@ -504,7 +504,7 @@ async def create_campaign(
 
 
 async def load_and_create_campaign(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     yaml_file: str,
     name: str,
     spec_block_assoc_name: str | None = None,
@@ -514,7 +514,7 @@ async def load_and_create_campaign(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     yaml_file: str
@@ -552,7 +552,7 @@ async def load_and_create_campaign(
 
 
 async def add_steps(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     fullname: str,
     child_configs: list[dict[str, Any]],
 ) -> db.Campaign:
@@ -560,7 +560,7 @@ async def add_steps(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     fullname: str
@@ -586,14 +586,14 @@ async def add_steps(
 
 
 async def load_error_types(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     yaml_file: str,
 ) -> list[db.PipetaskErrorType]:
     """Load a set of `PipetaskErrorType`s from a yaml file
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     yaml_file: str,
@@ -609,7 +609,7 @@ async def load_error_types(
 
 
 async def load_manifest_report(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     yaml_file: str,
     fullname: str,
     *,
@@ -619,7 +619,7 @@ async def load_manifest_report(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     yaml_file: str,
@@ -641,7 +641,7 @@ async def load_manifest_report(
 
 
 async def match_pipetask_errors(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     *,
     rematch: bool = False,
 ) -> list[db.PipetaskError]:
@@ -651,7 +651,7 @@ async def match_pipetask_errors(
 
     Parameters
     ----------
-    session : async_scoped_session
+    session : AnyAsyncSession
         DB session manager
 
     rematch: bool

--- a/src/lsst/cmservice/handlers/job_handler.py
+++ b/src/lsst/cmservice/handlers/job_handler.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy.ext.asyncio import async_scoped_session
-
 from ..common.enums import ErrorActionEnum, StatusEnum
 from ..common.errors import CMBadEnumError
 from ..db.element import ElementMixin
 from .element_handler import ElementHandler
 
 if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
     from ..db import Job
 
 
@@ -18,7 +17,7 @@ class JobHandler(ElementHandler):
 
     async def _post_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         element: ElementMixin,
         **kwargs: Any,
     ) -> StatusEnum:

--- a/src/lsst/cmservice/handlers/jobs.py
+++ b/src/lsst/cmservice/handlers/jobs.py
@@ -10,7 +10,6 @@ import yaml
 from anyio import Path, to_thread
 from fastapi.concurrency import run_in_threadpool
 from jinja2 import Environment, PackageLoader
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from lsst.ctrl.bps import BaseWmsService, WmsRunReport, WmsStates
 from lsst.utils import doImport
@@ -35,6 +34,10 @@ from ..db.task_set import TaskSet
 from ..db.wms_task_report import WmsTaskReport
 from .functions import compute_job_status, load_manifest_report, load_wms_reports, status_from_bps_report
 from .script_handler import FunctionHandler, ScriptHandler
+
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
 
 WMS_TO_TASK_STATUS_MAP = {
     WmsStates.UNKNOWN: TaskStatusEnum.missing,
@@ -64,7 +67,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -149,7 +152,7 @@ class BpsScriptHandler(ScriptHandler):
         #       unless they are unique to the submission and separated for
         #       readability. The use of any kind of "shared" or "global" config
         #       items breaks provenance for all campaigns that reference them.
-        bps_wms_extra_files = data_dict.get("bps_wms_extra_files", [])
+        bps_wms_extra_files: list = data_dict.get("bps_wms_extra_files", [])
         bps_wms_clustering_file = data_dict.get("bps_wms_clustering_file", None)
         bps_wms_resources_file = data_dict.get("bps_wms_resources_file", None)
         bps_wms_yaml_file = data_dict.get("bps_wms_yaml_file", None)
@@ -233,7 +236,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def _check_slurm_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         slurm_id: str | None,
         script: Script,
         parent: ElementMixin,
@@ -263,7 +266,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def _check_htcondor_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         htcondor_id: str | None,
         script: Script,
         parent: ElementMixin,
@@ -303,7 +306,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def launch(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -330,7 +333,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -358,7 +361,7 @@ class BpsScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -407,7 +410,7 @@ class BpsReportHandler(FunctionHandler):
 
     async def _load_wms_reports(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         job: Job,
         wms_workflow_id: str | None,
         **kwargs: Any,
@@ -462,7 +465,7 @@ class BpsReportHandler(FunctionHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin | Job,
         **kwargs: Any,
@@ -478,7 +481,7 @@ class BpsReportHandler(FunctionHandler):
 
     async def _do_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin | Job,
         **kwargs: Any,
@@ -497,7 +500,7 @@ class BpsReportHandler(FunctionHandler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -564,7 +567,7 @@ class ManifestReportScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -616,7 +619,7 @@ class ManifestReportLoadHandler(FunctionHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -644,7 +647,7 @@ class ManifestReportLoadHandler(FunctionHandler):
 
     async def _do_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin | Job,
         **kwargs: Any,
@@ -661,7 +664,7 @@ class ManifestReportLoadHandler(FunctionHandler):
 
     async def _load_pipetask_report(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         job: Job,
         pipetask_report_yaml: str,
         fake_status: StatusEnum | None = None,
@@ -688,7 +691,7 @@ class ManifestReportLoadHandler(FunctionHandler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,

--- a/src/lsst/cmservice/handlers/script_handler.py
+++ b/src/lsst/cmservice/handlers/script_handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from anyio import Path
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from ..common.bash import check_stamp_file, get_diagnostic_message, run_bash_job
 from ..common.enums import ErrorSourceEnum, ScriptMethodEnum, StatusEnum
@@ -26,6 +25,10 @@ from ..db.node import NodeMixin
 from ..db.script import Script
 from ..db.script_error import ScriptError
 
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
+
 logger = LOGGER.bind(module=__name__)
 
 DOUBLE_QUOTE = '"'
@@ -36,7 +39,7 @@ class BaseScriptHandler(Handler):
 
     async def process(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -129,7 +132,7 @@ class BaseScriptHandler(Handler):
 
     async def run_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         **kwargs: Any,
     ) -> tuple[bool, StatusEnum]:
@@ -145,7 +148,7 @@ class BaseScriptHandler(Handler):
 
     async def prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
     ) -> StatusEnum:
@@ -157,7 +160,7 @@ class BaseScriptHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -178,7 +181,7 @@ class BaseScriptHandler(Handler):
 
     async def launch(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -191,7 +194,7 @@ class BaseScriptHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -209,7 +212,7 @@ class BaseScriptHandler(Handler):
 
     async def check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -222,7 +225,7 @@ class BaseScriptHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -240,7 +243,7 @@ class BaseScriptHandler(Handler):
 
     async def review_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -253,7 +256,7 @@ class BaseScriptHandler(Handler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -272,7 +275,7 @@ class BaseScriptHandler(Handler):
 
     async def reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         node: NodeMixin,
         to_status: StatusEnum,
         *,
@@ -305,7 +308,7 @@ class BaseScriptHandler(Handler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -315,7 +318,7 @@ class BaseScriptHandler(Handler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -325,7 +328,7 @@ class BaseScriptHandler(Handler):
 
     async def update_status(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         status: StatusEnum,
         node: NodeMixin,
         **kwargs: Any,
@@ -352,7 +355,7 @@ class ScriptHandler(BaseScriptHandler):
 
     @staticmethod
     async def _check_stamp_file(
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         stamp_file: str | None,
         script: Script,
         parent: ElementMixin,
@@ -362,7 +365,7 @@ class ScriptHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         stamp_file: str | None
@@ -390,7 +393,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def _check_slurm_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         slurm_id: str | None,
         script: Script,
         parent: ElementMixin,
@@ -400,7 +403,7 @@ class ScriptHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         slurm_id : str
@@ -426,7 +429,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def _check_htcondor_job(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         htcondor_id: str | None,
         script: Script,
         parent: ElementMixin,
@@ -436,7 +439,7 @@ class ScriptHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         htcondor_id : str | None
@@ -462,7 +465,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -486,7 +489,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def launch(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -535,7 +538,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -581,7 +584,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -590,7 +593,7 @@ class ScriptHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -608,7 +611,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def _set_script_files(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         prod_area: str | Path,
     ) -> str:
@@ -620,7 +623,7 @@ class ScriptHandler(BaseScriptHandler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -649,7 +652,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -667,7 +670,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def launch(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -686,7 +689,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -703,7 +706,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def _do_prepare(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -712,7 +715,7 @@ class FunctionHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -730,7 +733,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def _do_run(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -739,7 +742,7 @@ class FunctionHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -757,7 +760,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def _do_check(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -766,7 +769,7 @@ class FunctionHandler(BaseScriptHandler):
 
         Parameters
         ----------
-        session : async_scoped_session
+        session : AnyAsyncSession
             DB session manager
 
         script: Script
@@ -784,7 +787,7 @@ class FunctionHandler(BaseScriptHandler):
 
     async def _reset_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,

--- a/src/lsst/cmservice/handlers/scripts.py
+++ b/src/lsst/cmservice/handlers/scripts.py
@@ -5,7 +5,6 @@ import textwrap
 from typing import TYPE_CHECKING, Any
 
 from anyio import Path
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from ..common.bash import write_bash_script
 from ..common.butler import (
@@ -23,6 +22,10 @@ from ..db.script import Script
 from ..db.step import Step
 from .script_handler import ScriptHandler
 
+if TYPE_CHECKING:
+    from ..common.types import AnyAsyncSession
+
+
 logger = LOGGER.bind(module=__name__)
 
 
@@ -31,7 +34,7 @@ class NullScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -58,7 +61,7 @@ class NullScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -82,7 +85,7 @@ class ChainCreateScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -117,7 +120,7 @@ class ChainCreateScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -148,7 +151,7 @@ class ChainPrependScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -178,7 +181,7 @@ class ChainPrependScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -210,7 +213,7 @@ class ChainCollectScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -257,7 +260,7 @@ class ChainCollectScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -288,7 +291,7 @@ class TagInputsScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -318,7 +321,7 @@ class TagInputsScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -345,7 +348,7 @@ class TagCreateScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -371,7 +374,7 @@ class TagCreateScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -400,7 +403,7 @@ class TagAssociateScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -428,7 +431,7 @@ class TagAssociateScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -462,7 +465,7 @@ class PrepareStepScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -505,7 +508,7 @@ class PrepareStepScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -527,7 +530,7 @@ class ResourceUsageScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -557,7 +560,7 @@ class ResourceUsageScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -584,7 +587,7 @@ class HipsMapsScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -649,7 +652,7 @@ class HipsMapsScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,
@@ -683,7 +686,7 @@ class ValidateScriptHandler(ScriptHandler):
 
     async def _write_script(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         parent: ElementMixin,
         **kwargs: Any,
@@ -710,7 +713,7 @@ class ValidateScriptHandler(ScriptHandler):
 
     async def _purge_products(
         self,
-        session: async_scoped_session,
+        session: AnyAsyncSession,
         script: Script,
         to_status: StatusEnum,
         *,

--- a/src/lsst/cmservice/main.py
+++ b/src/lsst/cmservice/main.py
@@ -3,13 +3,13 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI
-from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.http_client import http_client_dependency
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from . import __version__
 from .config import config
+from .db.session import db_session_dependency
 from .routers import (
     healthz,
     index,
@@ -96,9 +96,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     """Hook FastAPI init/cleanups."""
     app.state.tasks = set()
     # Dependency inits before app starts running
-    await db_session_dependency.initialize(config.db.url, config.db.password)
-    assert db_session_dependency._engine is not None
-    db_session_dependency._engine.echo = config.db.echo
+    await db_session_dependency.initialize()
+    assert db_session_dependency.engine is not None
 
     # App runs here...
     yield

--- a/src/lsst/cmservice/models/element.py
+++ b/src/lsst/cmservice/models/element.py
@@ -21,13 +21,13 @@ class ElementBase(BaseModel):
     metadata_: dict = Field(default_factory=dict)
 
     # Overrides for configuring child nodes
-    child_config: dict | str | None = None
+    child_config: dict | None = None
 
     # Overrides for making collection names
-    collections: dict | str | None = None
+    collections: dict | None = None
 
     # Overrides for which SpecBlocks to use in constructing child Nodes
-    spec_aliases: dict | str | None = None
+    spec_aliases: dict | None = None
 
     # Override for Callback handler class
     handler: str | None = None
@@ -75,13 +75,13 @@ class ElementUpdate(BaseModel):
     metadata_: dict | None = None
 
     # Overrides for configuring child nodes
-    child_config: dict | str | None = None
+    child_config: dict | None = None
 
     # Overrides for making collection names
-    collections: dict | str | None = None
+    collections: dict | None = None
 
     # Overrides for which SpecBlocks to use in constructing child Nodes
-    spec_aliases: dict | str | None = None
+    spec_aliases: dict | None = None
 
     # Override for Callback handler class
     handler: str | None = None

--- a/src/lsst/cmservice/models/interface.py
+++ b/src/lsst/cmservice/models/interface.py
@@ -138,13 +138,13 @@ class LoadAndCreateCampaign(YamlFileQuery):
     # If empty use {spec_name}#campaign
     spec_block_assoc_name: str | None = None
     # Parameter Overrides
-    data: dict | str | None = None
+    data: dict | None = None
     # Overrides for configuring child nodes
-    child_config: dict | str | None = None
+    child_config: dict | None = None
     # Overrides for making collection names
-    collections: dict | str | None = None
+    collections: dict | None = None
     # Overrides for which SpecBlocks to use in constructing child Nodes
-    spec_aliases: dict | str | None = None
+    spec_aliases: dict | None = None
     # Override for Callback handler class
     handler: str | None = None
     # Allow updating existing specifications

--- a/src/lsst/cmservice/models/specification.py
+++ b/src/lsst/cmservice/models/specification.py
@@ -14,16 +14,16 @@ class SpecificationBase(BaseModel):
     name: str
 
     # Parameter Overrides
-    data: dict | str | None = None
+    data: dict | None = None
 
     # Overrides for configuring child nodes
-    child_config: dict | str | None = None
+    child_config: dict | None = None
 
     # Overrides for making collection names
-    collections: dict | str | None = None
+    collections: dict | None = None
 
     # Overrides for which SpecBlocks to use in constructing child Nodes
-    spec_aliases: dict | str | None = None
+    spec_aliases: dict | None = None
 
 
 class SpecificationCreate(SpecificationBase):

--- a/src/lsst/cmservice/routers/actions.py
+++ b/src/lsst/cmservice/routers/actions.py
@@ -1,11 +1,11 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common.enums import StatusEnum
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from ..handlers import interface
 
 router = APIRouter(
@@ -21,7 +21,7 @@ router = APIRouter(
 )
 async def process(
     query: models.ProcessNodeQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> tuple[bool, StatusEnum]:
     """Invoke the interface.process function"""
     params = query.model_dump()
@@ -43,7 +43,7 @@ async def process(
 )
 async def reset_script(
     query: models.ResetScriptQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Script:
     """Invoke the interface.reset_script function"""
     params = query.model_dump()
@@ -63,7 +63,7 @@ async def reset_script(
 )
 async def rescue_job(
     query: models.NodeQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Job:
     """Invoke the interface.rescue_job function"""
     params = query.model_dump()
@@ -83,7 +83,7 @@ async def rescue_job(
 )
 async def mark_job_rescued(
     query: models.NodeQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> list[db.Job]:
     """Invoke the interface.mark_job_rescued function"""
     params = query.model_dump()
@@ -103,7 +103,7 @@ async def mark_job_rescued(
 )
 async def rematch_pipetask_errors(
     query: models.RematchQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> list[db.PipetaskError]:
     """Invoke the interface.match_pipetask_errors function"""
     params = query.model_dump()

--- a/src/lsst/cmservice/routers/campaigns.py
+++ b/src/lsst/cmservice/routers/campaigns.py
@@ -5,15 +5,15 @@ from typing import Annotated
 from uuid import uuid5
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common import timestamp
 from ..common.enums import DEFAULT_NAMESPACE
 from ..common.graph import graph_from_edge_list, graph_to_dict
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from ..handlers.functions import render_campaign_steps
 from . import wrappers
 
@@ -98,7 +98,7 @@ get_products = wrappers.get_element_products_function(router, DbClass)
 )
 async def post_row(
     row_create: models.CampaignCreate,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     background_tasks: BackgroundTasks,
 ) -> db.Campaign:
     try:
@@ -125,7 +125,7 @@ async def post_row(
 )
 async def get_step_graph(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> Mapping:
     # Determine the namespace UUID for the campaign
     campaign = await db.Campaign.get_row(session, row_id)
@@ -148,7 +148,7 @@ async def get_step_graph(
 )
 async def get_script_graph(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> Mapping:
     # Determine the namespace UUID for the campaign
     campaign = await db.Campaign.get_row(session, row_id)

--- a/src/lsst/cmservice/routers/groups.py
+++ b/src/lsst/cmservice/routers/groups.py
@@ -3,10 +3,10 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from . import wrappers
 
 # Template specialization
@@ -95,7 +95,7 @@ get_products = wrappers.get_element_products_function(router, DbClass)
 )
 async def rescue_job(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Job:
     """Invoke the Group.rescue_job function"""
     the_group = await DbClass.get_row(session, row_id)
@@ -110,7 +110,7 @@ async def rescue_job(
 )
 async def mark_job_rescued(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> list[db.Job]:
     """Invoke the Group.mark_job_rescued function"""
     the_group = await DbClass.get_row(session, row_id)

--- a/src/lsst/cmservice/routers/jobs.py
+++ b/src/lsst/cmservice/routers/jobs.py
@@ -4,12 +4,12 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common.errors import CMBadStateTransitionError, CMMissingIDError
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from ..handlers.functions import force_accept_node
 from . import wrappers
 
@@ -99,7 +99,7 @@ get_products = wrappers.get_element_products_function(router, DbClass)
 )
 async def get_errors(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> Sequence[db.PipetaskError]:
     try:
         async with session.begin():
@@ -121,7 +121,7 @@ async def get_errors(
 async def accept_job(
     *,
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     background_tasks: BackgroundTasks,
     force: bool = False,
     output_collection: str | None = None,

--- a/src/lsst/cmservice/routers/loaders.py
+++ b/src/lsst/cmservice/routers/loaders.py
@@ -1,10 +1,10 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from ..handlers import functions, interface
 
 router = APIRouter(
@@ -21,7 +21,7 @@ router = APIRouter(
 )
 async def add_steps(
     query: models.AddSteps,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Campaign:
     """Invoke the interface.add_steps function"""
     try:
@@ -40,7 +40,7 @@ async def add_steps(
 )
 async def load_specification(
     query: models.SpecificationLoad,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Specification:
     """Load a specification object fom a yaml file
 
@@ -49,7 +49,7 @@ async def load_specification(
     query: models.SpecificationLoad
         Details of what to load
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -73,7 +73,7 @@ async def load_specification(
 )
 async def load_and_create_campaign(
     query: models.LoadAndCreateCampaign,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Campaign:
     """Load a specification and use it to create a `Campaign`
 
@@ -82,7 +82,7 @@ async def load_and_create_campaign(
     query: models.LoadAndCreateCampaign
         Details of what to load and create
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -106,7 +106,7 @@ async def load_and_create_campaign(
 )
 async def load_error_types(
     query: models.YamlFileQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> list[db.PipetaskErrorType]:
     """Load a set of PipetaskErrorType object from a yaml file
 
@@ -115,7 +115,7 @@ async def load_error_types(
     query: models.YamlFileQuery
         Details of what to load
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -139,7 +139,7 @@ async def load_error_types(
 )
 async def load_manifest_report(
     query: models.LoadManifestReport,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> db.Job:
     """Load a pipetask report and associated it to a Job
 
@@ -148,7 +148,7 @@ async def load_manifest_report(
     query: models.LoadManifestReport
         Details of what to load
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns

--- a/src/lsst/cmservice/routers/queues.py
+++ b/src/lsst/cmservice/routers/queues.py
@@ -3,12 +3,12 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common.errors import CMMissingIDError
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from . import wrappers
 
 logger = LOGGER.bind(module=__name__)
@@ -51,7 +51,7 @@ update_row = wrappers.put_row_function(router, ResponseModelClass, UpdateModelCl
     summary="Process the associated element",
 )
 async def process_element(
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     row_id: int,
 ) -> bool:
     """Process associated element
@@ -61,7 +61,7 @@ async def process_element(
     row_id: int
         ID of the Queue row in question
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -86,7 +86,7 @@ async def process_element(
     summary="Toggle the pause status of a queue entry",
 )
 async def toggle_active(
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     row_id: int,
 ) -> bool:
     """Toggle the active status of a queue entry.
@@ -96,7 +96,7 @@ async def toggle_active(
     row_id: int
         ID of the Queue row in question
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -121,7 +121,7 @@ async def toggle_active(
     summary="Check how long to sleep based on what is running",
 )
 async def sleep_time(
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     row_id: int,
 ) -> int:
     """Check how long to sleep based on what is running
@@ -131,7 +131,7 @@ async def sleep_time(
     row_id: int
         ID of the Queue row in question
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns

--- a/src/lsst/cmservice/routers/scripts.py
+++ b/src/lsst/cmservice/routers/scripts.py
@@ -4,12 +4,12 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common.enums import StatusEnum
 from ..common.errors import CMMissingIDError
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 from . import wrappers
 
 # Template specialization
@@ -87,7 +87,7 @@ check_prerequisites = wrappers.get_node_check_prerequisites_function(router, DbC
 async def reset_script(
     row_id: int,
     query: models.ResetQuery,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> StatusEnum:
     """Reset a script to an earlier status
 
@@ -96,7 +96,7 @@ async def reset_script(
     row_id: int
         ID of the script in question
 
-    session: async_scoped_session
+    session: AnyAsyncSession
         DB session manager
 
     Returns
@@ -123,7 +123,7 @@ async def reset_script(
 )
 async def get_script_errors(
     row_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> Sequence[db.ScriptError]:
     try:
         async with session.begin():

--- a/src/lsst/cmservice/routers/wrappers.py
+++ b/src/lsst/cmservice/routers/wrappers.py
@@ -9,10 +9,9 @@ apply to all RowMixin, NodeMixin and ElementMixin classes.
 """
 
 from collections.abc import Callable, Sequence
-from typing import Annotated, TypeAlias
+from typing import TYPE_CHECKING, Annotated, TypeAlias
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from .. import db, models
 from ..common.enums import StatusEnum
@@ -26,8 +25,8 @@ logger = LOGGER.bind(module=__name__)
 
 def get_rows_no_parent_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that gets all the rows from a table
     and attaches that function to a router.
@@ -40,10 +39,10 @@ def get_rows_no_parent_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: TypeAlias
         Underlying database class
 
     Returns
@@ -54,13 +53,14 @@ def get_rows_no_parent_function(
 
     @router.get(
         "/list",
-        summary=f"List all the {db_class.class_string}",
+        summary=f"List all the {db_class.__qualname__}",
+        response_model=Sequence[response_model_class],
     )
     async def get_rows(
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
         skip: int = 0,
         limit: int = 100,
-    ) -> Sequence[response_model_class]:
+    ) -> Sequence[db.RowMixin]:
         try:
             async with session.begin():
                 return await db_class.get_rows(session, skip=skip, limit=limit)
@@ -73,8 +73,8 @@ def get_rows_no_parent_function(
 
 def get_rows_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that gets all the rows from a table
     and attaches that function to a router.
@@ -87,10 +87,10 @@ def get_rows_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: TypeAlias
         Underlying database class
 
     Returns
@@ -101,14 +101,15 @@ def get_rows_function(
 
     @router.get(
         "/list",
-        summary=f"List all the {db_class.class_string}",
+        summary=f"List all the {db_class.__qualname__}",
+        response_model=Sequence[response_model_class],
     )
     async def get_rows(
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
         parent_id: int | None = None,
         skip: int = 0,
         limit: int = 100,
-    ) -> Sequence[response_model_class]:
+    ) -> Sequence[db.RowMixin]:
         try:
             async with session.begin():
                 return await db_class.get_rows(
@@ -127,8 +128,8 @@ def get_rows_function(
 
 def get_row_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that gets a single row from a table (by ID)
     and attaches that function to a router.
@@ -138,7 +139,7 @@ def get_row_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -152,12 +153,13 @@ def get_row_function(
 
     @router.get(
         "/get/{row_id}",
-        summary=f"Retrieve a {db_class.class_string} by name",
+        summary=f"Retrieve a {db_class.__qualname__} by name",
+        response_model=response_model_class,
     )
     async def get_row(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.RowMixin:
         try:
             async with session.begin():
                 return await db_class.get_row(session, row_id)
@@ -173,8 +175,8 @@ def get_row_function(
 
 def get_row_by_fullname_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that gets a single row from a table (by fullname)
     and attaches that function to a router.
@@ -184,7 +186,7 @@ def get_row_by_fullname_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -198,12 +200,13 @@ def get_row_by_fullname_function(
 
     @router.get(
         "/get_row_by_fullname",
-        summary=f"Retrieve a {db_class.class_string} by name",
+        summary=f"Retrieve a {db_class.__qualname__} by name",
+        response_model=response_model_class,
     )
     async def get_row_by_fullname(
         fullname: str,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.RowMixin:
         try:
             async with session.begin():
                 return await db_class.get_row_by_fullname(session, fullname)
@@ -219,8 +222,8 @@ def get_row_by_fullname_function(
 
 def get_row_by_name_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that gets a single row from a table (by name)
     and attaches that function to a router.
@@ -230,7 +233,7 @@ def get_row_by_name_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -244,12 +247,13 @@ def get_row_by_name_function(
 
     @router.get(
         "/get_row_by_name",
-        summary=f"Retrieve a {db_class.class_string} by name",
+        summary=f"Retrieve a {db_class.__qualname__} by name",
+        response_model=response_model_class,
     )
     async def get_row_by_name(
         name: str,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.RowMixin:
         try:
             async with session.begin():
                 return await db_class.get_row_by_name(session, name)
@@ -265,9 +269,9 @@ def get_row_by_name_function(
 
 def post_row_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    create_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    create_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that creates a single row in a table
     and attaches that function to a router.
@@ -277,10 +281,10 @@ def post_row_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel,
+    response_model_class: TypeAlias,
         Pydantic class used to serialize the return value
 
-    create_model_class: TypeAlias = BaseModel,
+    create_model_class: TypeAlias,
         Pydantic class used to serialize the inputs value
 
     db_class: TypeAlias = db.RowMixin
@@ -296,12 +300,12 @@ def post_row_function(
         "/create",
         status_code=201,
         response_model=response_model_class,
-        summary=f"Create a {db_class.class_string}",
+        summary=f"Create a {db_class.__qualname__}",
     )
     async def post_row(
         row_create: create_model_class,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> db_class:
+    ) -> db.RowMixin:
         try:
             async with session.begin():
                 return await db_class.create_row(session, **row_create.model_dump())
@@ -314,7 +318,7 @@ def post_row_function(
 
 def delete_row_function(
     router: APIRouter,
-    db_class: TypeAlias = db.RowMixin,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that deletes a single row in a table
     and attaches that function to a router.
@@ -336,7 +340,7 @@ def delete_row_function(
     @router.delete(
         "/delete/{row_id}",
         status_code=204,
-        summary=f"Delete a {db_class.class_string}",
+        summary=f"Delete a {db_class.__qualname__}",
     )
     async def delete_row(
         row_id: int,
@@ -357,9 +361,9 @@ def delete_row_function(
 
 def put_row_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    update_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.RowMixin,
+    response_model_class: TypeAlias,
+    update_model_class: TypeAlias,
+    db_class: type[db.RowMixin],
 ) -> Callable:
     """Return a function that updates a single row in a table
     and attaches that function to a router.
@@ -369,10 +373,10 @@ def put_row_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return values
 
-    update_model_class: TypeAlias = BaseModel,
+    update_model_class: TypeAlias,
         Pydantic class used to serialize the input values
 
     db_class: TypeAlias = db.RowMixin
@@ -387,13 +391,13 @@ def put_row_function(
     @router.put(
         "/update/{row_id}",
         response_model=response_model_class,
-        summary=f"Update a {db_class.class_string}",
+        summary=f"Update a {db_class.__qualname__}",
     )
     async def update_row(
         row_id: int,
         row_update: update_model_class,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> db_class:
+    ) -> db.RowMixin:
         try:
             async with session.begin():
                 return await db_class.update_row(session, row_id, **row_update.model_dump())
@@ -409,7 +413,7 @@ def put_row_function(
 
 def get_node_spec_block_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets the SpecBlock associated to a Node.
 
@@ -418,7 +422,7 @@ def get_node_spec_block_function(
     router: APIRouter
         Router to attach the function to
 
-    db_class: TypeAlias = db.RowMixin
+    db_class: TypeAlias = db.NodeMixin
         Underlying database class
 
     Returns
@@ -429,12 +433,13 @@ def get_node_spec_block_function(
 
     @router.get(
         "/get/{row_id}/spec_block",
-        summary=f"Get the SpecBlock associated to a {db_class.class_string}",
+        summary=f"Get the SpecBlock associated to a {db_class.__qualname__}",
+        response_model=models.SpecBlock,
     )
     async def get_node_spec_block(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> models.SpecBlock:
+    ) -> db.SpecBlock:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -452,7 +457,7 @@ def get_node_spec_block_function(
 
 def get_node_specification_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets the Specification associated to a Node.
 
@@ -472,12 +477,13 @@ def get_node_specification_function(
 
     @router.get(
         "/get/{row_id}/specification",
-        summary=f"Get the Specification associated to a {db_class.class_string}",
+        summary=f"Get the Specification associated to a {db_class.__qualname__}",
+        response_model=models.Specification,
     )
     async def get_node_specification(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> models.Specification:
+    ) -> db.Specification:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -495,8 +501,8 @@ def get_node_specification_function(
 
 def get_node_parent_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets the parent Node associated to a Node.
 
@@ -505,7 +511,7 @@ def get_node_parent_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -519,12 +525,13 @@ def get_node_parent_function(
 
     @router.get(
         "/get/{row_id}/parent",
-        summary=f"Get the Parent associated to a {db_class.class_string}",
+        summary=f"Get the Parent associated to a {db_class.__qualname__}",
+        response_model=response_model_class,
     )
     async def get_node_parent(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -542,7 +549,7 @@ def get_node_parent_function(
 
 def get_node_resolved_collections_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets resolved collection names associated to a Node.
 
@@ -562,7 +569,7 @@ def get_node_resolved_collections_function(
 
     @router.get(
         "/get/{row_id}/resolved_collections",
-        summary=f"Get the resolved collections associated to a {db_class.class_string}",
+        summary=f"Get the resolved collections associated to a {db_class.__qualname__}",
     )
     async def get_node_resolved_collections(
         row_id: int,
@@ -585,7 +592,7 @@ def get_node_resolved_collections_function(
 
 def get_node_collections_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets collection names associated to a Node.
 
@@ -605,7 +612,7 @@ def get_node_collections_function(
 
     @router.get(
         "/get/{row_id}/collections",
-        summary=f"Get the collections associated to a {db_class.class_string}",
+        summary=f"Get the collections associated to a {db_class.__qualname__}",
     )
     async def get_node_collections(
         row_id: int,
@@ -628,7 +635,7 @@ def get_node_collections_function(
 
 def get_node_child_config_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets child_conifg dict associated to a Node.
 
@@ -648,7 +655,7 @@ def get_node_child_config_function(
 
     @router.get(
         "/get/{row_id}/child_config",
-        summary=f"Get the child_config associated to a {db_class.class_string}",
+        summary=f"Get the child_config associated to a {db_class.__qualname__}",
     )
     async def get_node_child_config(
         row_id: int,
@@ -671,7 +678,7 @@ def get_node_child_config_function(
 
 def get_node_data_dict_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function gets data_dict associated to a Node.
 
@@ -691,7 +698,7 @@ def get_node_data_dict_function(
 
     @router.get(
         "/get/{row_id}/data_dict",
-        summary=f"Get the data_dict associated to a {db_class.class_string}",
+        summary=f"Get the data_dict associated to a {db_class.__qualname__}",
     )
     async def get_node_data_dict(
         row_id: int,
@@ -714,7 +721,7 @@ def get_node_data_dict_function(
 
 def get_node_spec_aliases_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that gets the spec_aliases associated to a Node.
 
@@ -734,7 +741,7 @@ def get_node_spec_aliases_function(
 
     @router.get(
         "/get/{row_id}/spec_aliases",
-        summary=f"Get the spec_aliases associated to a {db_class.class_string}",
+        summary=f"Get the spec_aliases associated to a {db_class.__qualname__}",
     )
     async def get_node_spec_aliases(
         row_id: int,
@@ -757,8 +764,8 @@ def get_node_spec_aliases_function(
 
 def update_node_status_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that updates the status of a Node.
 
@@ -767,7 +774,7 @@ def update_node_status_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -783,12 +790,13 @@ def update_node_status_function(
         "/update/{row_id}/status",
         status_code=201,
         summary="Update status field associated to a node",
+        response_model=response_model_class,
     )
     async def update_node_status(
         row_id: int,
         query: models.UpdateStatusQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -808,8 +816,8 @@ def update_node_status_function(
 
 def update_node_collections_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that updates the collections associated to a Node.
 
@@ -818,7 +826,7 @@ def update_node_collections_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -833,13 +841,14 @@ def update_node_collections_function(
     @router.post(
         "/update/{row_id}/collections",
         status_code=201,
-        summary=f"Update the collections associated to a {db_class.class_string}",
+        summary=f"Update the collections associated to a {db_class.__qualname__}",
+        response_model=response_model_class,
     )
     async def update_node_collections(
         row_id: int,
         query: models.UpdateNodeQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -857,8 +866,8 @@ def update_node_collections_function(
 
 def update_node_child_config_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that updates the child_config associated to a Node.
 
@@ -867,7 +876,7 @@ def update_node_child_config_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -881,13 +890,14 @@ def update_node_child_config_function(
 
     @router.post(
         "/update/{row_id}/child_config",
-        summary=f"Update the child_config associated to a {db_class.class_string}",
+        summary=f"Update the child_config associated to a {db_class.__qualname__}",
+        response_model=response_model_class,
     )
     async def update_node_child_config(
         row_id: int,
         query: models.UpdateNodeQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -905,8 +915,8 @@ def update_node_child_config_function(
 
 def update_node_data_dict_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that updates the data_dict associated to a Node.
 
@@ -915,7 +925,7 @@ def update_node_data_dict_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -929,13 +939,14 @@ def update_node_data_dict_function(
 
     @router.post(
         "/update/{row_id}/data_dict",
-        summary=f"Update the data_dict associated to a {db_class.class_string}",
+        summary=f"Update the data_dict associated to a {db_class.__qualname__}",
+        response_model=response_model_class,
     )
     async def update_node_data_dict(
         row_id: int,
         query: models.UpdateNodeQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -953,8 +964,8 @@ def update_node_data_dict_function(
 
 def update_node_spec_aliases_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that updates the spec_aliases associated to a Node.
 
@@ -963,7 +974,7 @@ def update_node_spec_aliases_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -977,13 +988,14 @@ def update_node_spec_aliases_function(
 
     @router.post(
         "/update/{row_id}/spec_aliases",
-        summary=f"Update the spec_aliases associated to a {db_class.class_string}",
+        summary=f"Update the spec_aliases associated to a {db_class.__qualname__}",
+        response_model=response_model_class,
     )
     async def update_node_spec_aliases(
         row_id: int,
         query: models.UpdateNodeQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -1001,7 +1013,7 @@ def update_node_spec_aliases_function(
 
 def get_node_check_prerequisites_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that checks the prerequisites of a Node.
 
@@ -1021,7 +1033,7 @@ def get_node_check_prerequisites_function(
 
     @router.get(
         "/get/{row_id}/check_prerequisites",
-        summary=f"Check the prerequisites associated to a {db_class.class_string}",
+        summary=f"Check the prerequisites associated to a {db_class.__qualname__}",
     )
     async def node_check_prerequisites(
         row_id: int,
@@ -1044,8 +1056,8 @@ def get_node_check_prerequisites_function(
 
 def get_node_reject_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that marks a Node as rejected.
 
@@ -1054,7 +1066,7 @@ def get_node_reject_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -1069,12 +1081,13 @@ def get_node_reject_function(
     @router.post(
         "/action/{row_id}/reject",
         status_code=201,
-        summary=f"Mark a {db_class.class_string} as rejected",
+        summary=f"Mark a {db_class.__qualname__} as rejected",
+        response_model=response_model_class,
     )
     async def node_reject(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -1094,8 +1107,8 @@ def get_node_reject_function(
 
 def get_node_accept_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that marks a Node as accepted.
 
@@ -1104,7 +1117,7 @@ def get_node_accept_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -1119,12 +1132,13 @@ def get_node_accept_function(
     @router.post(
         "/action/{row_id}/accept",
         status_code=201,
-        summary=f"Mark a {db_class.class_string} as accepted",
+        summary=f"Mark a {db_class.__qualname__} as accepted",
+        response_model=response_model_class,
     )
     async def node_accept(
         row_id: int,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -1144,8 +1158,8 @@ def get_node_accept_function(
 
 def get_node_reset_function(
     router: APIRouter,
-    response_model_class: TypeAlias = BaseModel,
-    db_class: TypeAlias = db.NodeMixin,
+    response_model_class: TypeAlias,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function resets a Node status to waiting.
 
@@ -1154,7 +1168,7 @@ def get_node_reset_function(
     router: APIRouter
         Router to attach the function to
 
-    response_model_class: TypeAlias = BaseModel
+    response_model_class: TypeAlias
         Pydantic class used to serialize the return value
 
     db_class: TypeAlias = db.RowMixin
@@ -1169,13 +1183,14 @@ def get_node_reset_function(
     @router.post(
         "/action/{row_id}/reset",
         status_code=201,
-        summary=f"Mark a {db_class.class_string} as reseted",
+        summary=f"Mark a {db_class.__qualname__} as reseted",
+        response_model=response_model_class,
     )
     async def node_reset(
         row_id: int,
         query: models.ResetQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
-    ) -> response_model_class:
+    ) -> db.NodeMixin:
         try:
             async with session.begin():
                 the_node = await db_class.get_row(session, row_id)
@@ -1195,7 +1210,7 @@ def get_node_reset_function(
 
 def get_node_process_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that causes a Node to be processed.
 
@@ -1216,7 +1231,7 @@ def get_node_process_function(
     @router.post(
         "/action/{row_id}/process",
         status_code=201,
-        summary=f"Mark a {db_class.class_string} as processed",
+        summary=f"Mark a {db_class.__qualname__} as processed",
     )
     async def node_process(
         row_id: int,
@@ -1239,7 +1254,7 @@ def get_node_process_function(
 
 def get_node_run_check_function(
     router: APIRouter,
-    db_class: TypeAlias = db.NodeMixin,
+    db_class: type[db.NodeMixin],
 ) -> Callable:
     """Return a function that checks the status of a Node.
 
@@ -1260,7 +1275,7 @@ def get_node_run_check_function(
     @router.post(
         "/action/{row_id}/run_check",
         status_code=201,
-        summary=f"Mark a {db_class.class_string} as run_checked",
+        summary=f"Mark a {db_class.__qualname__} as run_checked",
     )
     async def node_run_check(
         row_id: int,
@@ -1283,7 +1298,7 @@ def get_node_run_check_function(
 
 def get_element_get_scripts_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function get the scripts associated to an Element.
 
@@ -1305,7 +1320,7 @@ def get_element_get_scripts_function(
         "/get/{row_id}/scripts",
         status_code=201,
         response_model=Sequence[models.Script],
-        summary=f"Get the scripts associated to a {db_class.class_string}",
+        summary=f"Get the scripts associated to a {db_class.__qualname__}",
     )
     async def element_get_scripts(
         row_id: int,
@@ -1329,7 +1344,7 @@ def get_element_get_scripts_function(
 
 def get_element_get_all_scripts_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function that gets all scripts associated to an Element.
 
@@ -1351,7 +1366,7 @@ def get_element_get_all_scripts_function(
         "/get/{row_id}/all_scripts",
         status_code=201,
         response_model=Sequence[models.Script],
-        summary=f"Get the all scripts associated to a {db_class.class_string}",
+        summary=f"Get the all scripts associated to a {db_class.__qualname__}",
     )
     async def element_get_all_scripts(
         row_id: int,
@@ -1374,7 +1389,7 @@ def get_element_get_all_scripts_function(
 
 def get_element_get_jobs_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function get the jobs associated to an Element.
 
@@ -1396,7 +1411,7 @@ def get_element_get_jobs_function(
         "/get/{row_id}/jobs",
         status_code=201,
         response_model=Sequence[models.Job],
-        summary=f"Get the jobs associated to a {db_class.class_string}",
+        summary=f"Get the jobs associated to a {db_class.__qualname__}",
     )
     async def element_get_jobs(
         row_id: int,
@@ -1419,7 +1434,7 @@ def get_element_get_jobs_function(
 
 def get_element_retry_script_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function that will retry a script
 
@@ -1441,13 +1456,15 @@ def get_element_retry_script_function(
         "/action/{row_id}/retry_script",
         status_code=201,
         response_model=models.Script,
-        summary=f"Retry a script associated to a {db_class.class_string}",
+        summary=f"Retry a script associated to a {db_class.__qualname__}",
     )
     async def element_retry_script(
         row_id: int,
         query: models.RetryScriptQuery,
         session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> db.Script:
+        if TYPE_CHECKING:
+            assert query.script_name is not None
         try:
             async with session.begin():
                 the_element = await db_class.get_row(session, row_id)
@@ -1468,7 +1485,7 @@ def get_element_retry_script_function(
 
 def get_element_wms_task_reports_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function get the WmsTaskReports associated to an Element.
 
@@ -1490,7 +1507,7 @@ def get_element_wms_task_reports_function(
         "/get/{row_id}/wms_task_reports",
         status_code=201,
         response_model=models.MergedWmsTaskReportDict,
-        summary=f"Get the WmsTaskReports associated to a {db_class.class_string}",
+        summary=f"Get the WmsTaskReports associated to a {db_class.__qualname__}",
     )
     async def element_get_wms_task_reports(
         row_id: int,
@@ -1513,7 +1530,7 @@ def get_element_wms_task_reports_function(
 
 def get_element_tasks_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function get the TaskSets associated to an Element.
 
@@ -1535,7 +1552,7 @@ def get_element_tasks_function(
         "/get/{row_id}/tasks",
         status_code=201,
         response_model=models.MergedTaskSetDict,
-        summary=f"Get the TaskSets associated to a {db_class.class_string}",
+        summary=f"Get the TaskSets associated to a {db_class.__qualname__}",
     )
     async def element_get_tasks(
         row_id: int,
@@ -1558,7 +1575,7 @@ def get_element_tasks_function(
 
 def get_element_products_function(
     router: APIRouter,
-    db_class: TypeAlias = db.ElementMixin,
+    db_class: type[db.ElementMixin],
 ) -> Callable:
     """Return a function get the ProductSets associated to an Element.
 
@@ -1580,7 +1597,7 @@ def get_element_products_function(
         "/get/{row_id}/products",
         status_code=201,
         response_model=models.MergedProductSetDict,
-        summary=f"Get the ProductSets associated to a {db_class.class_string}",
+        summary=f"Get the ProductSets associated to a {db_class.__qualname__}",
     )
     async def element_get_products(
         row_id: int,

--- a/src/lsst/cmservice/routers/wrappers.py
+++ b/src/lsst/cmservice/routers/wrappers.py
@@ -13,13 +13,13 @@ from typing import Annotated, TypeAlias
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from .. import db, models
 from ..common.enums import StatusEnum
 from ..common.errors import CMBadStateTransitionError, CMMissingFullnameError, CMMissingIDError
 from ..common.logging import LOGGER
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
 
 logger = LOGGER.bind(module=__name__)
 
@@ -57,7 +57,7 @@ def get_rows_no_parent_function(
         summary=f"List all the {db_class.class_string}",
     )
     async def get_rows(
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
         skip: int = 0,
         limit: int = 100,
     ) -> Sequence[response_model_class]:
@@ -104,7 +104,7 @@ def get_rows_function(
         summary=f"List all the {db_class.class_string}",
     )
     async def get_rows(
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
         parent_id: int | None = None,
         skip: int = 0,
         limit: int = 100,
@@ -156,7 +156,7 @@ def get_row_function(
     )
     async def get_row(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -202,7 +202,7 @@ def get_row_by_fullname_function(
     )
     async def get_row_by_fullname(
         fullname: str,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -248,7 +248,7 @@ def get_row_by_name_function(
     )
     async def get_row_by_name(
         name: str,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -300,7 +300,7 @@ def post_row_function(
     )
     async def post_row(
         row_create: create_model_class,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> db_class:
         try:
             async with session.begin():
@@ -340,7 +340,7 @@ def delete_row_function(
     )
     async def delete_row(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> None:
         try:
             async with session.begin():
@@ -392,7 +392,7 @@ def put_row_function(
     async def update_row(
         row_id: int,
         row_update: update_model_class,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> db_class:
         try:
             async with session.begin():
@@ -433,7 +433,7 @@ def get_node_spec_block_function(
     )
     async def get_node_spec_block(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> models.SpecBlock:
         try:
             async with session.begin():
@@ -476,7 +476,7 @@ def get_node_specification_function(
     )
     async def get_node_specification(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> models.Specification:
         try:
             async with session.begin():
@@ -523,7 +523,7 @@ def get_node_parent_function(
     )
     async def get_node_parent(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -566,7 +566,7 @@ def get_node_resolved_collections_function(
     )
     async def get_node_resolved_collections(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> dict[str, str]:
         try:
             async with session.begin():
@@ -609,7 +609,7 @@ def get_node_collections_function(
     )
     async def get_node_collections(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> dict[str, str]:
         try:
             async with session.begin():
@@ -652,7 +652,7 @@ def get_node_child_config_function(
     )
     async def get_node_child_config(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> dict[str, str | int]:
         try:
             async with session.begin():
@@ -695,7 +695,7 @@ def get_node_data_dict_function(
     )
     async def get_node_data_dict(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> dict[str, str]:
         try:
             async with session.begin():
@@ -738,7 +738,7 @@ def get_node_spec_aliases_function(
     )
     async def get_node_spec_aliases(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> dict[str, str]:
         try:
             async with session.begin():
@@ -787,7 +787,7 @@ def update_node_status_function(
     async def update_node_status(
         row_id: int,
         query: models.UpdateStatusQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -838,7 +838,7 @@ def update_node_collections_function(
     async def update_node_collections(
         row_id: int,
         query: models.UpdateNodeQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -886,7 +886,7 @@ def update_node_child_config_function(
     async def update_node_child_config(
         row_id: int,
         query: models.UpdateNodeQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -934,7 +934,7 @@ def update_node_data_dict_function(
     async def update_node_data_dict(
         row_id: int,
         query: models.UpdateNodeQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -982,7 +982,7 @@ def update_node_spec_aliases_function(
     async def update_node_spec_aliases(
         row_id: int,
         query: models.UpdateNodeQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -1025,7 +1025,7 @@ def get_node_check_prerequisites_function(
     )
     async def node_check_prerequisites(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> bool:
         try:
             async with session.begin():
@@ -1073,7 +1073,7 @@ def get_node_reject_function(
     )
     async def node_reject(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -1123,7 +1123,7 @@ def get_node_accept_function(
     )
     async def node_accept(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -1174,7 +1174,7 @@ def get_node_reset_function(
     async def node_reset(
         row_id: int,
         query: models.ResetQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> response_model_class:
         try:
             async with session.begin():
@@ -1220,7 +1220,7 @@ def get_node_process_function(
     )
     async def node_process(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> tuple[bool, StatusEnum]:
         try:
             async with session.begin():
@@ -1264,7 +1264,7 @@ def get_node_run_check_function(
     )
     async def node_run_check(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> tuple[bool, StatusEnum]:
         try:
             async with session.begin():
@@ -1309,7 +1309,7 @@ def get_element_get_scripts_function(
     )
     async def element_get_scripts(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
         script_name: str = "",
     ) -> list[db.Script]:
         try:
@@ -1355,7 +1355,7 @@ def get_element_get_all_scripts_function(
     )
     async def element_get_all_scripts(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> list[db.Script]:
         try:
             async with session.begin():
@@ -1400,7 +1400,7 @@ def get_element_get_jobs_function(
     )
     async def element_get_jobs(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> list[db.Job]:
         try:
             async with session.begin():
@@ -1446,7 +1446,7 @@ def get_element_retry_script_function(
     async def element_retry_script(
         row_id: int,
         query: models.RetryScriptQuery,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> db.Script:
         try:
             async with session.begin():
@@ -1494,7 +1494,7 @@ def get_element_wms_task_reports_function(
     )
     async def element_get_wms_task_reports(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> models.MergedWmsTaskReportDict:
         try:
             async with session.begin():
@@ -1539,7 +1539,7 @@ def get_element_tasks_function(
     )
     async def element_get_tasks(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> models.MergedTaskSetDict:
         try:
             async with session.begin():
@@ -1584,7 +1584,7 @@ def get_element_products_function(
     )
     async def element_get_products(
         row_id: int,
-        session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+        session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     ) -> models.MergedProductSetDict:
         try:
             async with session.begin():

--- a/src/lsst/cmservice/web_app/app.py
+++ b/src/lsst/cmservice/web_app/app.py
@@ -12,13 +12,10 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
-from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.http_client import http_client_dependency
-from sqlalchemy.ext.asyncio import async_scoped_session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from lsst.cmservice.common.enums import LevelEnum
-from lsst.cmservice.config import config
 from lsst.cmservice.web_app.pages.campaigns import get_all_campaigns, get_campaign_details, search_campaigns
 from lsst.cmservice.web_app.pages.group_details import get_group_by_id
 from lsst.cmservice.web_app.pages.job_details import get_job_by_id
@@ -36,14 +33,16 @@ from lsst.cmservice.web_app.utils.utils import (
     update_data_dict,
 )
 
+from ..common.types import AnyAsyncSession
+from ..db.session import db_session_dependency
+
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncGenerator:
     """Hook FastAPI init/cleanups."""
     # Dependency inits before app starts running
-    await db_session_dependency.initialize(config.db.url, config.db.password)
-    assert db_session_dependency._engine is not None
-    db_session_dependency._engine.echo = config.db.echo
+    await db_session_dependency.initialize()
+    assert db_session_dependency.engine is not None
 
     # App runs here...
     yield
@@ -92,7 +91,7 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
 @web_app.get("/campaigns/", response_class=HTMLResponse)
 async def get_campaigns(
     request: Request,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         async with session.begin():
@@ -137,7 +136,7 @@ async def error_page(
 async def search(
     request: Request,
     search_term: Annotated[str, Form()],
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         results = await search_campaigns(session, search_term)
@@ -163,7 +162,7 @@ async def search(
 async def get_steps(
     request: Request,
     campaign_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         campaign = await get_campaign_by_id(session, campaign_id)
@@ -194,7 +193,7 @@ async def get_step(
     request: Request,
     campaign_id: int,
     step_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         step, step_groups, step_scripts = await get_step_details_by_id(session, step_id)
@@ -218,7 +217,7 @@ async def get_step(
 async def get_group(
     request: Request,
     group_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         group_details, jobs, scripts = await get_group_by_id(session, group_id)
@@ -243,7 +242,7 @@ async def get_job(
     step_id: int,
     group_id: int,
     job_id: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         job_details, scripts = await get_job_by_id(session, job_id)
@@ -269,7 +268,7 @@ async def get_job(
 @web_app.get("/script/{campaign_id}/{step_id}/{group_id}/{job_id}/{script_id}/", response_class=HTMLResponse)
 async def get_script(
     request: Request,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
     script_id: int,
     campaign_id: int | None = None,
     step_id: int | None = None,
@@ -329,7 +328,7 @@ async def update_element_collections(
     request: Request,
     element_id: int,
     element_type: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         element = await get_element(session, element_id, element_type)
@@ -357,7 +356,7 @@ async def update_element_child_config(
     request: Request,
     element_id: int,
     element_type: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         element = await get_element(session, element_id, element_type)
@@ -388,7 +387,7 @@ async def update_element_data_dict(
     request: Request,
     element_id: int,
     element_type: int,
-    session: Annotated[async_scoped_session, Depends(db_session_dependency)],
+    session: Annotated[AnyAsyncSession, Depends(db_session_dependency)],
 ) -> HTMLResponse:
     try:
         element = await get_element(session, element_id, element_type)

--- a/src/lsst/cmservice/web_app/pages/campaigns.py
+++ b/src/lsst/cmservice/web_app/pages/campaigns.py
@@ -2,14 +2,14 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from lsst.cmservice.common.enums import LevelEnum, StatusEnum
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import Campaign, Group
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
-async def get_campaign_details(session: async_scoped_session, campaign: Campaign) -> dict:
+async def get_campaign_details(session: AnyAsyncSession, campaign: Campaign) -> dict:
     if TYPE_CHECKING:
         assert isinstance(campaign.data, dict)
     collections = await campaign.resolve_collections(session, throw_overrides=False)
@@ -46,21 +46,21 @@ async def get_campaign_details(session: async_scoped_session, campaign: Campaign
     return campaign_details
 
 
-async def search_campaigns(session: async_scoped_session, search_term: str) -> Sequence:
+async def search_campaigns(session: AnyAsyncSession, search_term: str) -> Sequence:
     q = select(Campaign).where(Campaign.name.contains(search_term))
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.all()
 
 
-async def get_campaign_groups(session: async_scoped_session, campaign: Campaign) -> Sequence:
+async def get_campaign_groups(session: AnyAsyncSession, campaign: Campaign) -> Sequence:
     q = select(Group).where(Group.c_ == campaign)
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.all()
 
 
-async def get_all_campaigns(session: async_scoped_session) -> Sequence:
+async def get_all_campaigns(session: AnyAsyncSession) -> Sequence:
     q = select(Campaign)
     async with session.begin_nested():
         results = await session.scalars(q)

--- a/src/lsst/cmservice/web_app/pages/group_details.py
+++ b/src/lsst/cmservice/web_app/pages/group_details.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import Group, NodeMixin
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
 async def get_group_by_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     group_id: int,
     campaign_id: int | None = None,
     step_id: int | None = None,
@@ -78,7 +78,7 @@ async def get_group_by_id(
         return group_details, jobs, scripts
 
 
-async def get_group_jobs(session: async_scoped_session, group: Group) -> list[dict]:
+async def get_group_jobs(session: AnyAsyncSession, group: Group) -> list[dict]:
     jobs = await group.children(session)
     return [
         {
@@ -97,7 +97,7 @@ async def get_group_jobs(session: async_scoped_session, group: Group) -> list[di
     ]
 
 
-async def get_group_scripts(session: async_scoped_session, group: Group) -> list[dict]:
+async def get_group_scripts(session: AnyAsyncSession, group: Group) -> list[dict]:
     scripts = await group.get_scripts(session)
     return [
         {
@@ -112,6 +112,6 @@ async def get_group_scripts(session: async_scoped_session, group: Group) -> list
     ]
 
 
-async def get_group_node(session: async_scoped_session, group_id: int) -> NodeMixin:
+async def get_group_node(session: AnyAsyncSession, group_id: int) -> NodeMixin:
     group = await Group.get_row(session, group_id)
     return group

--- a/src/lsst/cmservice/web_app/pages/job_details.py
+++ b/src/lsst/cmservice/web_app/pages/job_details.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import Job, NodeMixin
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
 async def get_job_by_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     job_id: int,
 ) -> tuple[dict[str, Any] | None, list[dict[Any, Any]] | None]:
     q = select(Job).where(Job.id == job_id)
@@ -72,7 +72,7 @@ async def get_job_by_id(
         return job_details, scripts
 
 
-async def get_job_scripts(session: async_scoped_session, job: Job) -> list[dict]:
+async def get_job_scripts(session: AnyAsyncSession, job: Job) -> list[dict]:
     scripts = await job.get_scripts(session)
     job_scripts = [
         {
@@ -88,6 +88,6 @@ async def get_job_scripts(session: async_scoped_session, job: Job) -> list[dict]
     return job_scripts
 
 
-async def get_job_node(session: async_scoped_session, job_id: int) -> NodeMixin:
+async def get_job_node(session: AnyAsyncSession, job_id: int) -> NodeMixin:
     job = await Job.get_row(session, job_id)
     return job

--- a/src/lsst/cmservice/web_app/pages/script_details.py
+++ b/src/lsst/cmservice/web_app/pages/script_details.py
@@ -2,8 +2,8 @@ from typing import Any
 
 import starlette.requests
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import Group, Job, NodeMixin, Script, Step
 from lsst.cmservice.web_app.utils.utils import map_status
 
@@ -20,7 +20,7 @@ def is_script_collection(collection: tuple[str, str]) -> bool:
 
 
 async def get_script_by_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     script_id: int,
     request: starlette.requests.Request,
     campaign_id: int | None = None,
@@ -103,27 +103,27 @@ async def get_script_by_id(
         return script_details
 
 
-async def get_step_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
+async def get_step_id_by_fullname(session: AnyAsyncSession, fullname: str) -> int | None:
     q = select(Step.id).where(Step.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.one_or_none()
 
 
-async def get_group_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
+async def get_group_id_by_fullname(session: AnyAsyncSession, fullname: str) -> int | None:
     q = select(Group.id).where(Group.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.one_or_none()
 
 
-async def get_job_id_by_fullname(session: async_scoped_session, fullname: str) -> int | None:
+async def get_job_id_by_fullname(session: AnyAsyncSession, fullname: str) -> int | None:
     q = select(Job.id).where(Job.fullname == fullname)
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.one_or_none()
 
 
-async def get_script_node(session: async_scoped_session, script_id: int) -> NodeMixin:
+async def get_script_node(session: AnyAsyncSession, script_id: int) -> NodeMixin:
     script = await Script.get_row(session, script_id)
     return script

--- a/src/lsst/cmservice/web_app/pages/step_details.py
+++ b/src/lsst/cmservice/web_app/pages/step_details.py
@@ -1,14 +1,13 @@
 from typing import Any
 
-from sqlalchemy.ext.asyncio import async_scoped_session
-
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import NodeMixin, Step
 from lsst.cmservice.web_app.pages.steps import get_step_details
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
 async def get_step_details_by_id(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     step_id: int,
 ) -> tuple[Any, list[dict[Any, Any]], list[dict[Any, Any]]]:
     step = await Step.get_row(session, step_id)
@@ -23,7 +22,7 @@ async def get_step_details_by_id(
     return step_details, groups, scripts
 
 
-async def get_step_groups(session: async_scoped_session, step: Step) -> list[dict]:
+async def get_step_groups(session: AnyAsyncSession, step: Step) -> list[dict]:
     groups = await step.children(session)
     step_groups = [
         {
@@ -41,7 +40,7 @@ async def get_step_groups(session: async_scoped_session, step: Step) -> list[dic
     return step_groups
 
 
-async def get_step_scripts(session: async_scoped_session, step: Step) -> list[dict]:
+async def get_step_scripts(session: AnyAsyncSession, step: Step) -> list[dict]:
     scripts = await step.get_scripts(session)
     step_scripts = [
         {
@@ -57,6 +56,6 @@ async def get_step_scripts(session: async_scoped_session, step: Step) -> list[di
     return step_scripts
 
 
-async def get_step_node(session: async_scoped_session, step_id: int) -> NodeMixin:
+async def get_step_node(session: AnyAsyncSession, step_id: int) -> NodeMixin:
     step = await Step.get_row(session, step_id)
     return step

--- a/src/lsst/cmservice/web_app/pages/steps.py
+++ b/src/lsst/cmservice/web_app/pages/steps.py
@@ -1,21 +1,21 @@
 from collections.abc import Sequence
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_scoped_session
 
 from lsst.cmservice.common.enums import StatusEnum
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import Campaign, Step
 from lsst.cmservice.web_app.utils.utils import map_status
 
 
-async def get_campaign_steps(session: async_scoped_session, campaign_id: int) -> Sequence:
+async def get_campaign_steps(session: AnyAsyncSession, campaign_id: int) -> Sequence:
     q = select(Step).where(Step.parent_id == campaign_id).order_by(Step.id)
     async with session.begin_nested():
         results = await session.scalars(q)
         return results.all()
 
 
-async def get_step_details(session: async_scoped_session, step: Step) -> dict:
+async def get_step_details(session: AnyAsyncSession, step: Step) -> dict:
     step_groups = await step.children(session)
     no_groups = len(list(step_groups))
     no_groups_completed = len([group for group in step_groups if group.status is StatusEnum.accepted])
@@ -37,7 +37,7 @@ async def get_step_details(session: async_scoped_session, step: Step) -> dict:
     return step_details
 
 
-async def get_campaign_by_id(session: async_scoped_session, campaign_id: int) -> Campaign | None:
+async def get_campaign_by_id(session: AnyAsyncSession, campaign_id: int) -> Campaign | None:
     q = select(Campaign).where(Campaign.id == campaign_id)
     async with session.begin_nested():
         results = await session.scalars(q)

--- a/src/lsst/cmservice/web_app/utils/utils.py
+++ b/src/lsst/cmservice/web_app/utils/utils.py
@@ -1,6 +1,5 @@
-from sqlalchemy.ext.asyncio import async_scoped_session
-
 from lsst.cmservice.common.enums import LevelEnum, StatusEnum
+from lsst.cmservice.common.types import AnyAsyncSession
 from lsst.cmservice.db import NodeMixin
 
 
@@ -17,26 +16,22 @@ def map_status(status: StatusEnum) -> str | None:
     return None
 
 
-async def update_data_dict(session: async_scoped_session, element: NodeMixin, data_dict: dict) -> NodeMixin:
+async def update_data_dict(session: AnyAsyncSession, element: NodeMixin, data_dict: dict) -> NodeMixin:
     updated_element = await element.update_data_dict(session, **data_dict)
     return updated_element
 
 
-async def update_collections(
-    session: async_scoped_session, element: NodeMixin, collections: dict
-) -> NodeMixin:
+async def update_collections(session: AnyAsyncSession, element: NodeMixin, collections: dict) -> NodeMixin:
     updated_element = await element.update_collections(session, **collections)
     return updated_element
 
 
-async def update_child_config(
-    session: async_scoped_session, element: NodeMixin, child_config: dict
-) -> NodeMixin:
+async def update_child_config(session: AnyAsyncSession, element: NodeMixin, child_config: dict) -> NodeMixin:
     updated_element = await element.update_child_config(session, **child_config)
     return updated_element
 
 
-async def get_element(session: async_scoped_session, element_id: int, element_type: int) -> NodeMixin | None:
+async def get_element(session: AnyAsyncSession, element_id: int, element_type: int) -> NodeMixin | None:
     from lsst.cmservice.web_app.pages.group_details import get_group_node
     from lsst.cmservice.web_app.pages.job_details import get_job_node
     from lsst.cmservice.web_app.pages.script_details import get_script_node

--- a/tests/db/test_handlers.py
+++ b/tests/db/test_handlers.py
@@ -8,17 +8,18 @@ import pytest
 import structlog
 from _pytest.monkeypatch import MonkeyPatch
 from safir.database import create_async_session
-from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from lsst.cmservice import db
 from lsst.cmservice.common.enums import LevelEnum, StatusEnum
+from lsst.cmservice.common.types import AnyAsyncSession
 
 from .util_functions import cleanup, create_tree
 
 
 @pytest.mark.asyncio()
 async def check_run_script(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     parent: db.ElementMixin,
     script_name: str,
     spec_block_name: str,
@@ -47,7 +48,7 @@ async def check_run_script(
 
 @pytest.mark.asyncio()
 async def check_script(
-    session: async_scoped_session,
+    session: AnyAsyncSession,
     parent: db.ElementMixin,
     script_name: str,
     spec_block_name: str,

--- a/tests/routers/util_functions.py
+++ b/tests/routers/util_functions.py
@@ -1,18 +1,16 @@
 from pathlib import Path
-from typing import TypeAlias, TypeVar
+from typing import TypeAlias
 
 from httpx import AsyncClient, Response
 from pydantic import TypeAdapter
 
 from lsst.cmservice import models
 from lsst.cmservice.common.enums import LevelEnum, StatusEnum
+from lsst.cmservice.common.types import AnyCampaignElement
 from lsst.cmservice.config import config
 
-T = TypeVar("T")
-E = TypeVar("E", models.Group, models.Campaign, models.Step, models.Job)
 
-
-def check_and_parse_response(
+def check_and_parse_response[T](
     response: Response,
     return_class: type[T],
 ) -> T:
@@ -32,7 +30,7 @@ def expect_failed_response(
 
 async def add_scripts(
     client: AsyncClient,
-    element: E,
+    element: AnyCampaignElement,
     api_version: str,
 ) -> tuple[list[models.Script], models.Dependency]:
     prep_script_model = models.ScriptCreate(
@@ -183,7 +181,7 @@ async def delete_all_rows(
     client: AsyncClient,
     api_version: str,
     entry_class_name: str,
-    entry_class: TypeAlias = models.ElementMixin,
+    entry_class: TypeAlias,
 ) -> None:
     response = await client.get(f"{config.asgi.prefix}/{api_version}/{entry_class_name}/list")
     rows = check_and_parse_response(response, list[entry_class])
@@ -242,7 +240,7 @@ async def check_update_methods(
     api_version: str,
     entry: models.ElementMixin,
     entry_class_name: str,
-    entry_class: TypeAlias = models.ElementMixin,
+    entry_class: type[models.ElementMixin],
 ) -> None:
     update_model = models.UpdateNodeQuery(
         fullname=entry.fullname,
@@ -252,8 +250,8 @@ async def check_update_methods(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/{entry.id}/data_dict",
         content=update_model.model_dump_json(),
     )
-    check = check_and_parse_response(response, entry_class)
-    assert check.data["test"] == "dummy", "update_data_dict failed"
+    check_a = check_and_parse_response(response, entry_class)
+    assert check_a.data["test"] == "dummy", "update_data_dict failed"
 
     response = await client.post(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/-1/data_dict",
@@ -264,8 +262,8 @@ async def check_update_methods(
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}/data_dict",
     )
-    check = check_and_parse_response(response, dict)
-    assert check["test"] == "dummy", "get_data_dict failed"
+    check_b = check_and_parse_response(response, dict)
+    assert check_b["test"] == "dummy", "get_data_dict failed"
 
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/-1/data_dict",
@@ -280,8 +278,9 @@ async def check_update_methods(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/{entry.id}/collections",
         content=update_model.model_dump_json(),
     )
-    check = check_and_parse_response(response, entry_class)
-    assert check.collections["test"] == "dummy", "update_collections failed"
+    check_c = check_and_parse_response(response, entry_class)
+    assert check_c.collections is not None
+    assert check_c.collections["test"] == "dummy", "update_collections failed"
 
     response = await client.post(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/-1/collections",
@@ -292,8 +291,8 @@ async def check_update_methods(
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}/collections",
     )
-    check = check_and_parse_response(response, dict)
-    assert check["test"] == "dummy", "get_collections failed"
+    check_d = check_and_parse_response(response, dict)
+    assert check_d["test"] == "dummy", "get_collections failed"
 
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/-1/collections",
@@ -303,8 +302,8 @@ async def check_update_methods(
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}/resolved_collections",
     )
-    check = check_and_parse_response(response, dict)
-    assert check["test"] == "dummy", "get_resolved_collections failed"
+    check_e = check_and_parse_response(response, dict)
+    assert check_e["test"] == "dummy", "get_resolved_collections failed"
 
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/-1/resolved_collections",
@@ -319,8 +318,9 @@ async def check_update_methods(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/{entry.id}/child_config",
         content=update_model.model_dump_json(),
     )
-    check = check_and_parse_response(response, entry_class)
-    assert check.child_config["test"] == "dummy", "update_child_config failed"
+    check_f = check_and_parse_response(response, entry_class)
+    assert check_f.child_config is not None
+    assert check_f.child_config["test"] == "dummy", "update_child_config failed"
 
     response = await client.post(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/-1/child_config",
@@ -331,8 +331,8 @@ async def check_update_methods(
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}/child_config",
     )
-    check = check_and_parse_response(response, dict)
-    assert check["test"] == "dummy", "get_child_config failed"
+    check_g = check_and_parse_response(response, dict)
+    assert check_g["test"] == "dummy", "get_child_config failed"
 
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/-1/child_config",
@@ -347,8 +347,9 @@ async def check_update_methods(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/{entry.id}/spec_aliases",
         content=update_model.model_dump_json(),
     )
-    check = check_and_parse_response(response, entry_class)
-    assert check.spec_aliases["test"] == "dummy", "update_spec_aliases failed"
+    check_h = check_and_parse_response(response, entry_class)
+    assert check_h.spec_aliases is not None
+    assert check_h.spec_aliases["test"] == "dummy", "update_spec_aliases failed"
 
     response = await client.post(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/update/-1/spec_aliases",
@@ -359,8 +360,8 @@ async def check_update_methods(
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}/spec_aliases",
     )
-    check = check_and_parse_response(response, dict)
-    assert check["test"] == "dummy", "get_spec_aliases failed"
+    check_i = check_and_parse_response(response, dict)
+    assert check_i["test"] == "dummy", "get_spec_aliases failed"
 
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/-1/spec_aliases",
@@ -670,12 +671,12 @@ async def check_scripts(
     expect_failed_response(response, 404)
 
 
-async def check_get_methods(
+async def check_get_methods[E: AnyCampaignElement](
     client: AsyncClient,
     api_version: str,
     entry: E,
     entry_class_name: str,
-    entry_class: TypeAlias = models.ElementMixin,
+    entry_class: type[E],
 ) -> None:
     response = await client.get(
         f"{config.asgi.prefix}/{api_version}/{entry_class_name}/get/{entry.id}",


### PR DESCRIPTION
Where possible, use Python 3.12-style generic types. The largest area of impact is the migration away from "async_scoped_session" to "AsyncSession" in the database session dependency and the attendant migration away from a `safir`-provided sessionmaker.

Where reasonable, refactor inconsistent or incorrect use of TypeAliases. Where there is disagreement between pylance (VS Code) and mypy, endeavor to please both but favor mypy over pylance. In some cases, the new `ty` static type checker is used to help identify issues or as a tie-breaker (ha ha).