### PR TITLE
DM-51505 : Implement v2 Node and Edge routes

### DIFF
--- a/src/lsst/cmservice/common/graph.py
+++ b/src/lsst/cmservice/common/graph.py
@@ -1,8 +1,10 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, MutableSet, Sequence
 
 import networkx as nx
+from sqlalchemy import select
 
 from ..db import Script, ScriptDependency, Step, StepDependency
+from ..db.campaigns_v2 import Edge, Node
 from ..parsing.string import parse_element_fullname
 from .types import AnyAsyncSession
 
@@ -35,8 +37,125 @@ async def graph_from_edge_list(
     return g
 
 
+async def graph_from_edge_list_v2(
+    edges: Sequence[Edge],
+    node_type: type[Node],
+    session: AnyAsyncSession,
+) -> nx.DiGraph:
+    """Given a sequence of Edges, create a directed graph for these
+    edges with nodes derived from database lookups of the related objects.
+    """
+    g = nx.DiGraph()
+    g.add_edges_from([(e.source, e.target) for e in edges])
+
+    # The graph understands the nodes in terms of the IDs used in the edges,
+    # but we want to hydrate the entire Node model for subsequent users of this
+    # graph to reference without dipping back to the Database.
+    for node in g.nodes:
+        s = select(Node).where(Node.id == node)
+        db_node: Node = (await session.execute(s)).scalars().one()
+
+        # This Node is going on an adventure where it does not need to drag its
+        # SQLAlchemy baggage along, so we expunge it from the session before
+        # adding it to the graph.
+        session.expunge(db_node)
+        g.nodes[node]["model"] = db_node
+
+    # TODO validate graph now raise exception, or leave it to the caller?
+    return g
+
+
 def graph_to_dict(g: nx.DiGraph) -> Mapping:
     """Renders a networkx directed graph to a mapping format suitable for JSON
     serialization.
     """
     return nx.node_link_data(g, edges="edges")
+
+
+def validate_graph(g: nx.DiGraph, source: str = "START", sink: str = "END") -> bool:
+    """Validates a graph by asserting by traversal that a complete and correct
+    path exists between `source` and `sink` nodes.
+
+    "Correct" means that there are no cycles or isolate nodes (nodes with
+    degree 0) and no nodes with degree 1.
+    """
+    try:
+        # Test that G is a directed graph with no cycles
+        is_valid = nx.is_directed_acyclic_graph(g)
+        assert is_valid
+
+        # And that any path from source to sink exists
+        is_valid = nx.has_path(g, source, sink)
+        assert is_valid
+
+        # Guard against bad graphs where START and/or END have been connected
+        # such that they are no longer the only source and sink
+        ...
+
+        # Test that there are no isolated Nodes in the graph. A node becomes
+        # isolated if it was involved with an edge that has been removed from
+        # G with no replacement edge added, in which case the node should also
+        # be removed.
+        is_valid = nx.number_of_isolates(g) == 0
+        assert is_valid
+
+        # TODO Given the set of nodes in the graph, consider all paths in G
+        #      from source to sink, making sure every node appears in a path?
+
+        # Every node in G that is not the START/END node must have a degree
+        # of at least 2 (one inbound and one outbound edge). If G has any
+        # node with a degree of 1, it cannot be considered valid.
+        g_degree_view: Iterable = nx.degree(g, (n for n in g.nodes if n not in [source, sink]))
+        is_valid = min([d[1] for d in g_degree_view]) > 1
+        assert is_valid
+    except (nx.exception.NodeNotFound, AssertionError):
+        return False
+    return True
+
+
+def processable_graph_nodes(g: nx.DiGraph) -> Iterable[Node]:
+    """Traverse the graph G and produce an iterator of any nodes that are
+    candidates for processing, i.e., their status is waiting/prepared/running
+    and their ancestors are complete/successful. Graph nodes in a failed state
+    will block the graph and prevent candidacy for subsequent nodes.
+
+    Yields
+    ------
+    `lsst.cmservice.db.campaigns_v2.Node`
+        A Node ORM object that has been ``expunge``d from its ``Session``.
+
+    Notes
+    -----
+    This function operates only on valid graphs (see `validate_graph()`) that
+    have been built by the `graph_from_edge_list_v2()` function, where each
+    graph-node is decorated with a "model" attribute referring to an expunged
+    instance of ``Node``. This ``Node`` can be ``add``ed back to a ``Session``
+    and manipulated in the usual way.
+    """
+    processable_nodes: MutableSet[Node] = set()
+
+    # A valid campaign graph will have only one source (START) with in_degree 0
+    # and only one sink (END) with out_degree 0
+    source = next(v for v, d in g.in_degree() if d == 0)
+    sink = next(v for v, d in g.out_degree() if d == 0)
+
+    # For each path through the graph, evaluate the state of nodes to determine
+    # which nodes are up for processing. When there are multiple paths, we have
+    # parallelization and common ancestors may be evaluated more than once,
+    # which is an exercise in optimization left as a TODO
+    for path in nx.all_simple_paths(g, source, sink):
+        for n in path:
+            node: Node = g.nodes[n]["model"]
+            if node.status.is_processable_element():
+                processable_nodes.add(node)
+                # We found a processable node in this path, stop traversal
+                break
+            elif node.status.is_bad():
+                # We reached a failed node in this path, it is blocked
+                break
+            else:
+                # This node must be in a "successful" terminal state
+                continue
+
+    # the inspection should stop when there are no more nodes to check
+    yield from processable_nodes

--- a/src/lsst/cmservice/db/campaigns_v2.py
+++ b/src/lsst/cmservice/db/campaigns_v2.py
@@ -100,6 +100,12 @@ class CampaignUpdate(BaseSQLModel):
 class NodeBase(BaseSQLModel):
     """nodes_v2 db table"""
 
+    def __hash__(self) -> int:
+        """A Node is hashable according to its unique ID, so it can be used in
+        sets and other places hashable types are required.
+        """
+        return self.id.int
+
     id: UUID = Field(primary_key=True)
     name: str
     namespace: UUID
@@ -108,7 +114,7 @@ class NodeBase(BaseSQLModel):
         default=ManifestKind.other,
         sa_column=Column("kind", Enum(ManifestKind, length=20, native_enum=False, create_constraint=False)),
     )
-    status: StatusField | None = Field(
+    status: StatusField = Field(
         default=StatusEnum.waiting,
         sa_column=Column("status", Enum(StatusEnum, length=20, native_enum=False, create_constraint=False)),
     )

--- a/src/lsst/cmservice/db/manifests_v2.py
+++ b/src/lsst/cmservice/db/manifests_v2.py
@@ -5,6 +5,7 @@ not necessarily represent the object's database or ORM model.
 """
 
 from typing import Self
+from uuid import uuid4
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 
@@ -97,5 +98,45 @@ class CampaignManifest(Manifest[CampaignMetadata, ManifestSpec]):
         """Validate an Campaign Manifest after a model has been created."""
         if self.kind is not ManifestKind.campaign:
             raise ValueError("Campaigns may only be created from a <campaign> manifest")
+
+        return self
+
+
+class EdgeMetadata(ManifestMetadata):
+    """Metadata model for an Edge Manifest.
+
+    A default random alphanumeric 8-byte name is generated if no name provided.
+    """
+
+    name: str = Field(default_factory=lambda: uuid4().hex[:8])
+
+
+class EdgeSpec(ManifestSpec):
+    """Spec model for an Edge Manifest."""
+
+    source: str
+    target: str
+
+
+class EdgeManifest(Manifest[EdgeMetadata, EdgeSpec]):
+    """validating model for Edges"""
+
+    @model_validator(mode="after")
+    def custom_model_validator(self, info: ValidationInfo) -> Self:
+        """Validate an Edge Manifest after a model has been created."""
+        if self.kind is not ManifestKind.edge:
+            raise ValueError("Edges may only be created from an <edge> manifest")
+
+        return self
+
+
+class NodeManifest(Manifest[VersionedMetadata, ManifestSpec]):
+    """validating model for Nodes"""
+
+    @model_validator(mode="after")
+    def custom_model_validator(self, info: ValidationInfo) -> Self:
+        """Validate a Node Manifest after a model has been created."""
+        if self.kind is not ManifestKind.node:
+            raise ValueError("Nodes may only be created from an <node> manifest")
 
         return self

--- a/src/lsst/cmservice/routers/v2/__init__.py
+++ b/src/lsst/cmservice/routers/v2/__init__.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter
 
 from . import (
     campaigns,
+    edges,
     manifests,
+    nodes,
 )
 
 router = APIRouter(
@@ -10,4 +12,6 @@ router = APIRouter(
 )
 
 router.include_router(campaigns.router)
+router.include_router(edges.router)
 router.include_router(manifests.router)
+router.include_router(nodes.router)

--- a/src/lsst/cmservice/routers/v2/edges.py
+++ b/src/lsst/cmservice/routers/v2/edges.py
@@ -9,7 +9,7 @@ from typing import Annotated
 from uuid import UUID, uuid5
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from sqlmodel import select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from ...common.logging import LOGGER
@@ -46,7 +46,8 @@ async def read_edges_collection(
     For campaign-scoped edges, one should use the /campaigns/{}/edges route.
     """
     try:
-        edges = await session.exec(select(Edge).offset(offset).limit(limit))
+        statement = select(Edge).order_by(col(Edge.name).desc()).offset(offset).limit(limit)
+        edges = await session.exec(statement)
         response.headers["Next"] = (
             request.url_for("read_edges_collection")
             .include_query_params(offset=(offset + limit), limit=limit)

--- a/src/lsst/cmservice/routers/v2/edges.py
+++ b/src/lsst/cmservice/routers/v2/edges.py
@@ -1,0 +1,209 @@
+"""http routers for managing Edges.
+
+The /edges endpoint supports a collection resource and single resources
+representing edge objects within CM-Service.
+"""
+
+from collections.abc import Sequence
+from typing import Annotated
+from uuid import UUID, uuid5
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from ...common.logging import LOGGER
+from ...db.campaigns_v2 import Campaign, Edge
+from ...db.manifests_v2 import EdgeManifest
+from ...db.session import db_session_dependency
+
+# TODO should probably bind a logger to the fastapi app or something
+logger = LOGGER.bind(module=__name__)
+
+
+# Build the router
+router = APIRouter(
+    prefix="/edges",
+    tags=["edges", "v2"],
+)
+
+
+@router.get(
+    "/",
+    summary="Get a list of edges",
+)
+async def read_edges_collection(
+    request: Request,
+    response: Response,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+    offset: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(le=100)] = 10,
+) -> Sequence[Edge]:
+    """Fetches and returns all edges known to the service.
+
+    Notes
+    -----
+    For campaign-scoped edges, one should use the /campaigns/{}/edges route.
+    """
+    try:
+        edges = await session.exec(select(Edge).offset(offset).limit(limit))
+        response.headers["Next"] = (
+            request.url_for("read_edges_collection")
+            .include_query_params(offset=(offset + limit), limit=limit)
+            .__str__()
+        )
+        response.headers["Previous"] = (
+            request.url_for("read_edges_collection")
+            .include_query_params(offset=(offset - limit), limit=limit)
+            .__str__()
+        )
+        return edges.all()
+    except Exception as msg:
+        logger.exception()
+        raise HTTPException(status_code=500, detail=f"{str(msg)}") from msg
+
+
+@router.get(
+    "/{edge_name}",
+    summary="Get edge detail",
+)
+async def read_edge_resource(
+    request: Request,
+    response: Response,
+    edge_name: str,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+) -> Edge:
+    """Fetch a single edge from the database given the edge name or id.
+
+    The response headers include links to the connected nodes, the associated
+    campaign, and to the graph with which the edge is associated (i.e., the
+    collection of all campaign edges).
+    """
+    s = select(Edge)
+    # The input could be UUID or a literal name.
+    try:
+        if edge_id := UUID(edge_name):
+            s = s.where(Edge.id == edge_id)
+    except ValueError:
+        s = s.where(Edge.name == edge_name)
+
+    edge = (await session.exec(s)).one_or_none()
+    if edge is None:
+        raise HTTPException(status_code=404)
+    response.headers["Self"] = request.url_for("read_edge_resource", edge_name=edge.id).__str__()
+    response.headers["Source"] = request.url_for("read_node_resource", node_name=edge.source).__str__()
+    response.headers["Target"] = request.url_for("read_node_resource", node_name=edge.target).__str__()
+    response.headers["Campaign"] = request.url_for(
+        "read_campaign_resource", campaign_name=edge.namespace
+    ).__str__()
+    response.headers["Graph"] = request.url_for(
+        "read_campaign_edge_collection", campaign_name=edge.namespace
+    ).__str__()
+    return edge
+
+
+@router.post(
+    "/",
+    summary="Add a edge resource",
+)
+async def create_edge_resource(
+    request: Request,
+    response: Response,
+    manifest: EdgeManifest,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+) -> Edge:
+    """Creates a new edge from a Manifest.
+
+    The Manifest must be of type "edge" and include a campaign namespace in its
+    metadata. If an edge name is not provided, a random name is assigned.
+
+    ```
+    ---
+    apiVersion: "io.lsst.cmservice/v1"
+    kind: edge
+    metadata:
+        name: {edge name}
+        namespace: {campaign uuid}
+    spec:
+        source: {node name or id}
+        target: {ndoe name or id}
+    ```
+    """
+    edge_name = manifest.metadata_.name
+    source_node = manifest.spec.source
+    target_node = manifest.spec.target
+
+    # A edge must exist in the namespace of an existing campaign
+    edge_namespace: str = manifest.metadata_.namespace
+    try:
+        edge_namespace_uuid: UUID | None = UUID(edge_namespace)
+    except ValueError:
+        # get the campaign ID by its name to use as a namespace
+        edge_namespace_uuid = (
+            await session.exec(select(Campaign.id).where(Campaign.name == edge_namespace))
+        ).one_or_none()
+
+    # it is an error if the provided namespace (campaign) does not exist
+    if edge_namespace_uuid is None:
+        raise HTTPException(status_code=422, detail="Requested campaign namespace does not exist.")
+
+    # an edge may specify the source and target nodes by name and version,
+    # which means the UUID of these nodes is deterministic, or we could go to
+    # the database to discover them + validate their existence.
+    # TODO the edge spec should support mappings for source/target nodes but
+    # for now assume the provided name has `.vN` appended to it already or
+    # default to v1
+    source_node = f"{source_node}.1" if "." not in source_node else str(source_node)
+    target_node = f"{target_node}.1" if "." not in target_node else str(target_node)
+
+    # An edge's name is not necessarily deterministic, so for the ID we'll
+    # construct a UUID5 that involves the nodes instead
+    edge_id = uuid5(edge_namespace_uuid, f"{source_node}->{target_node}")
+
+    edge = Edge(
+        id=edge_id,
+        name=edge_name,
+        namespace=edge_namespace_uuid,
+        source=uuid5(edge_namespace_uuid, source_node),
+        target=uuid5(edge_namespace_uuid, target_node),
+        configuration=manifest.spec.model_dump(),
+    )
+
+    # The merge operation is effectively an upsert should an edge matching the
+    # id already exist
+    edge = await session.merge(edge, load=True)
+    await session.commit()
+
+    response.headers["Self"] = request.url_for("read_edge_resource", edge_name=edge.id).__str__()
+    response.headers["Source"] = request.url_for("read_node_resource", node_name=edge.source).__str__()
+    response.headers["Target"] = request.url_for("read_node_resource", node_name=edge.target).__str__()
+    response.headers["Campaign"] = request.url_for(
+        "read_campaign_resource", campaign_name=edge.namespace
+    ).__str__()
+    response.headers["Graph"] = request.url_for(
+        "read_campaign_edge_collection", campaign_name=edge.namespace
+    ).__str__()
+    return edge
+
+
+@router.delete(
+    "/{edge_id}",
+    summary="Delete edge",
+    status_code=204,
+)
+async def delete_edge_resource(
+    request: Request,
+    response: Response,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+    edge_id: UUID,
+) -> None:
+    """Delete an edge given its id."""
+    s = select(Edge).where(Edge.id == edge_id)
+    edge_to_delete = (await session.exec(s)).one_or_none()
+
+    if edge_to_delete is None:
+        raise HTTPException(status_code=404, detail="No such edge.")
+
+    await session.delete(edge_to_delete)
+    await session.commit()
+    return None

--- a/src/lsst/cmservice/routers/v2/edges.py
+++ b/src/lsst/cmservice/routers/v2/edges.py
@@ -126,7 +126,7 @@ async def create_edge_resource(
         namespace: {campaign uuid}
     spec:
         source: {node name or id}
-        target: {ndoe name or id}
+        target: {node name or id}
     ```
     """
     edge_name = manifest.metadata_.name
@@ -153,6 +153,7 @@ async def create_edge_resource(
     # TODO the edge spec should support mappings for source/target nodes but
     # for now assume the provided name has `.vN` appended to it already or
     # default to v1
+    # TODO support node id in spec
     source_node = f"{source_node}.1" if "." not in source_node else str(source_node)
     target_node = f"{target_node}.1" if "." not in target_node else str(target_node)
 

--- a/src/lsst/cmservice/routers/v2/nodes.py
+++ b/src/lsst/cmservice/routers/v2/nodes.py
@@ -177,7 +177,7 @@ async def update_node_resource(
     A Node's name, id, kind, or namespace may not be modified by this
     method, and attempts to do so will produce a 4XX client error.
 
-    This PATCH endpoint supports RFC6902 json-patch and RFCrequests.
+    This PATCH endpoint supports RFC6902 json-patch requests.
 
     Notes
     -----
@@ -232,5 +232,9 @@ async def update_node_resource(
     session.add(new_manifest_db)
     await session.commit()
 
-    # TODO response headers
+    response.headers["Self"] = request.url_for("read_node_resource", node_name=new_manifest_db.id).__str__()
+    response.headers["Campaign"] = request.url_for(
+        "read_campaign_resource", campaign_name=new_manifest_db.namespace
+    ).__str__()
+
     return new_manifest_db

--- a/src/lsst/cmservice/routers/v2/nodes.py
+++ b/src/lsst/cmservice/routers/v2/nodes.py
@@ -1,0 +1,236 @@
+"""http routers for managing Nodes.
+
+The /nodes endpoint supports a collection resource and single resources
+representing node objects within CM-Service.
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Annotated
+from uuid import UUID, uuid5
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from ...common.jsonpatch import JSONPatch, JSONPatchError, apply_json_patch
+from ...common.logging import LOGGER
+from ...db.campaigns_v2 import Campaign, Node
+from ...db.manifests_v2 import NodeManifest
+from ...db.session import db_session_dependency
+
+# TODO should probably bind a logger to the fastapi app or something
+logger = LOGGER.bind(module=__name__)
+
+
+# Build the router
+router = APIRouter(
+    prefix="/nodes",
+    tags=["nodes", "v2"],
+)
+
+
+@router.get(
+    "/",
+    summary="Get a list of nodes",
+)
+async def read_nodes_collection(
+    request: Request,
+    response: Response,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+    offset: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(le=100)] = 10,
+) -> Sequence[Node]:
+    """Fetches and returns all nodes known to the service.
+
+    Notes
+    -----
+    For campaign-scoped nodes, one should use the /campaigns/{}/nodes route.
+    """
+    try:
+        nodes = await session.exec(select(Node).offset(offset).limit(limit))
+        response.headers["Next"] = (
+            request.url_for("read_nodes_collection")
+            .include_query_params(offset=(offset + limit), limit=limit)
+            .__str__()
+        )
+        response.headers["Previous"] = (
+            request.url_for("read_nodes_collection")
+            .include_query_params(offset=(offset - limit), limit=limit)
+            .__str__()
+        )
+        return nodes.all()
+    except Exception as msg:
+        logger.exception()
+        raise HTTPException(status_code=500, detail=f"{str(msg)}") from msg
+
+
+@router.get(
+    "/{node_name}",
+    summary="Get node detail",
+)
+async def read_node_resource(
+    request: Request,
+    response: Response,
+    node_name: str,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+) -> Node:
+    """Fetch a single node from the database given either the node id
+    or its name.
+    """
+    s = select(Node)
+    # The input could be a campaign UUID or it could be a literal name.
+    try:
+        if node_id := UUID(node_name):
+            s = s.where(Node.id == node_id)
+    except ValueError:
+        s = s.where(Node.name == node_name)
+
+    node = (await session.exec(s)).one_or_none()
+    if node is None:
+        raise HTTPException(status_code=404)
+    response.headers["Self"] = request.url_for("read_node_resource", node_name=node.id).__str__()
+    response.headers["Campaign"] = request.url_for(
+        "read_campaign_resource", campaign_name=node.namespace
+    ).__str__()
+    return node
+
+
+@router.post(
+    "/",
+    summary="Add a node resource",
+)
+async def create_node_resource(
+    request: Request,
+    response: Response,
+    manifest: NodeManifest,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+) -> Node:
+    node_name = manifest.metadata_.name
+    node_namespace = manifest.metadata_.namespace
+
+    try:
+        node_namespace_uuid: UUID | None = UUID(node_namespace)
+    except ValueError:
+        # get the campaign ID by its name to use as a namespace
+        node_namespace_uuid = (
+            await session.exec(select(Campaign.id).where(Campaign.name == node_namespace))
+        ).one_or_none()
+
+    # it is an error if the provided namespace (campaign) does not exist
+    # FIXME but this could also be handled by FK constraints
+    if node_namespace_uuid is None:
+        raise HTTPException(status_code=404, detail="Requested campaign namespace does not exist.")
+
+    # A node must be a new version if name+namespace already exists
+    # - check db for node as name+namespace, get current version and increment
+    node_version = int(manifest.metadata_.version)
+
+    s = (
+        select(Node)
+        .where(Node.name == node_name)
+        .where(Node.namespace == node_namespace_uuid)
+        .order_by(col(Node.version).desc())
+        .limit(1)
+    )
+    previous_node = (await session.exec(s)).one_or_none()
+
+    node_version = previous_node.version if previous_node else node_version
+    node_version += 1
+    node = Node(
+        id=uuid5(node_namespace_uuid, f"{node_name}.{node_version}"),
+        name=node_name,
+        namespace=node_namespace_uuid,
+        version=node_version,
+        configuration=manifest.spec.model_dump(),
+    )
+
+    # Put the node in the database
+    session.add(node)
+    await session.commit()
+    await session.refresh(node)
+    response.headers["Self"] = request.url_for("read_node_resource", node_name=node.id).__str__()
+    response.headers["Campaign"] = request.url_for(
+        "read_campaign_resource", campaign_name=node.namespace
+    ).__str__()
+    return node
+
+
+@router.patch(
+    "/{node_name_or_id}",
+    summary="Update node detail",
+    status_code=202,
+)
+async def update_node_resource(
+    request: Request,
+    response: Response,
+    session: Annotated[AsyncSession, Depends(db_session_dependency)],
+    node_name_or_id: str,
+    patch_data: Sequence[JSONPatch],
+) -> Node:
+    """Partial update method for nodes.
+
+    A Nodes's spec or metadata may be updated with this PATCH operation. All
+    updates to a Node creates a new version of the Node instead of
+    updating an existing record in-place. This preserves history and keeps
+    previous node versions available.
+
+    A Node's name, id, kind, or namespace may not be modified by this
+    method, and attempts to do so will produce a 4XX client error.
+
+    This PATCH endpoint supports RFC6902 json-patch and RFCrequests.
+
+    Notes
+    -----
+    - This API always targets the latest version of a manifest when applying
+      a patch. This requires and maintains a "linear" sequence of versions;
+      it is not permissible to "patch" a previous version and create a "tree"-
+      like history of manifests. For exmaple, every manifest may be diffed
+      against any previous version without having to consider branches.
+    """
+    use_rfc6902 = False
+    if request.headers["Content-Type"] == "application/json-patch+json":
+        use_rfc6902 = True
+    else:
+        raise HTTPException(status_code=406, detail="Unsupported Content-Type")
+
+    if TYPE_CHECKING:
+        assert use_rfc6902
+
+    s = select(Node)
+    # The input could be a UUID or it could be a literal name.
+    try:
+        if _id := UUID(node_name_or_id):
+            s = s.where(Node.id == _id)
+    except ValueError:
+        s = s.where(Node.name == node_name_or_id)
+
+    # we want to order and sort by version, in descending order, so we always
+    # fetch only the most recent version of manifest
+    # FIXME this implies that when a node ID is provided, it should be an
+    # error if it is not the most recent version.
+    s = s.order_by(col(Node.version).desc()).limit(1)
+
+    old_manifest = (await session.exec(s)).one_or_none()
+    if old_manifest is None:
+        raise HTTPException(status_code=404, detail="No such node")
+
+    new_manifest = old_manifest.model_dump(by_alias=True)
+    new_manifest["version"] += 1
+    new_manifest["id"] = uuid5(new_manifest["namespace"], f"{new_manifest['name']}.{new_manifest['version']}")
+
+    for patch in patch_data:
+        try:
+            apply_json_patch(patch, new_manifest)
+        except JSONPatchError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unable to process one or more patch operations: {e}",
+            )
+
+    # create Manifest from new_manifest, add to session, and commit
+    new_manifest_db = Node.model_validate(new_manifest)
+    session.add(new_manifest_db)
+    await session.commit()
+
+    # TODO response headers
+    return new_manifest_db

--- a/tests/common/test_jsonpatch.py
+++ b/tests/common/test_jsonpatch.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from lsst.cmservice.common.jsonpatch import JSONPatch, JSONPatchError, apply_json_patch
+from lsst.cmservice.common.jsonpatch import JSONPatch, JSONPatchError, apply_json_merge, apply_json_patch
 
 
 @pytest.fixture
@@ -148,3 +148,17 @@ def test_jsonpatch_test(target_object: dict[str, Any]) -> None:
     op = JSONPatch(op="test", path="/spec/a_list/-", value="bob_alice")
     with pytest.raises(JSONPatchError):
         _ = apply_json_patch(op, target_object)
+
+
+def test_json_merge_patch(target_object: dict[str, Any]) -> None:
+    """Tests the RFC7396 JSON Merge patch function."""
+
+    patch = {
+        "metadata": {"owner": None, "pilot": "bob_loblaw"},
+        "spec": {"new_key": {"new_key": "new_value"}},
+    }
+    new_object = apply_json_merge(patch, target_object)
+
+    assert new_object["metadata"]["pilot"] == "bob_loblaw"
+    assert "owner" not in new_object["metadata"]
+    assert new_object["spec"]["new_key"]["new_key"] == "new_value"

--- a/tests/v2/test_edge_routes.py
+++ b/tests/v2/test_edge_routes.py
@@ -1,0 +1,142 @@
+"""Tests v2 fastapi edge routes"""
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+"""All tests in this module will run in the same event loop."""
+
+
+async def test_list_delete_no_edges(aclient: AsyncClient) -> None:
+    """Tests listing and deleting edges when there are no edges available."""
+    x = await aclient.get("/cm-service/v2/edges")
+    assert x.is_success
+    assert len(x.json()) == 0
+
+    x = await aclient.get(f"/cm-service/v2/edges/{uuid4()}")
+    assert x.status_code == 404
+
+    x = await aclient.delete(f"/cm-service/v2/edges/{uuid4()}")
+    assert x.status_code == 404
+
+
+async def test_edge_negative(aclient: AsyncClient) -> None:
+    """Tests edge route negative outcomes."""
+
+    # negative test: failing request model validation
+    x = await aclient.post(
+        "cm-service/v2/edges",
+        json={
+            "kind": "no_such_kind",
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: using wrong manifest kind
+    x = await aclient.post(
+        "cm-service/v2/edges",
+        json={
+            "kind": "other",
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: missing edge source or target
+    x = await aclient.post(
+        "cm-service/v2/edges",
+        json={
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[8:], "namespace": "test_campaign"},
+            "spec": {
+                "source": "START",
+            },
+        },
+    )
+    assert x.is_client_error
+
+    x = await aclient.post(
+        "cm-service/v2/edges",
+        json={
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[8:], "namespace": "test_campaign"},
+            "spec": {
+                "target": "END",
+            },
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: missing campaign namespace
+    x = await aclient.post(
+        "cm-service/v2/edges",
+        json={
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[8:]},
+            "spec": {"source": "START", "target": "END"},
+        },
+    )
+    assert x.is_client_error
+
+    # negative: fail to delete an edge using a non-uuid string (like a name)
+    x = await aclient.delete(
+        "/cm-service/v2/edges/not_an_edge_id",
+    )
+    assert x.status_code == 422
+
+
+async def test_edge_lifecycle(aclient: AsyncClient) -> None:
+    """Tests edge lifecycle."""
+    campaign_name = uuid4().hex[:8]
+
+    # Create a campaign for edges. Campaigns come with START and END nodes.
+    x = await aclient.post(
+        "/cm-service/v2/campaigns",
+        json={
+            "kind": "campaign",
+            "metadata": {"name": campaign_name},
+            "spec": {},
+        },
+    )
+    assert x.is_success
+    campaign_id = x.json()["id"]
+
+    # Create an edge between START and END
+    x = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "kind": "edge",
+            "metadata": {
+                "name": uuid4().hex[8:],
+                "namespace": campaign_id,
+            },
+            "spec": {
+                "source": "START",
+                "target": "END",
+            },
+        },
+    )
+    assert x.is_success
+    assert "Campaign" in x.headers
+    edge = x.json()
+    edge_name = edge["name"]
+    edge_self_url = x.headers["Self"]
+    target_node_url = x.headers["Target"]
+    source_node_url = x.headers["Source"]
+
+    # Verify header links to source and target nodes
+    x = await aclient.get(source_node_url)
+    assert x.is_success
+    assert x.json()["name"] == "START"
+
+    x = await aclient.get(target_node_url)
+    assert x.is_success
+    assert x.json()["name"] == "END"
+
+    x = await aclient.get(f"/cm-service/v2/edges/{edge_name}")
+    assert x.is_success
+    edge = x.json()
+
+    x = await aclient.delete(f"{edge_self_url}")
+    assert x.is_success

--- a/tests/v2/test_graph.py
+++ b/tests/v2/test_graph.py
@@ -1,0 +1,217 @@
+"""Tests graph operations using v2 objects"""
+
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import networkx as nx
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from lsst.cmservice.common.enums import StatusEnum
+from lsst.cmservice.common.graph import graph_from_edge_list_v2, processable_graph_nodes, validate_graph
+from lsst.cmservice.common.types import AnyAsyncSession
+from lsst.cmservice.db.campaigns_v2 import Edge, Node
+
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+"""All tests in this module will run in the same event loop."""
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def test_campaign(aclient: AsyncClient) -> AsyncGenerator[str]:
+    """Fixture managing a test campaign with two (additional) nodes."""
+    campaign_name = uuid4().hex[-8:]
+    node_ids = []
+
+    x = await aclient.post(
+        "/cm-service/v2/campaigns",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "campaign",
+            "metadata": {"name": campaign_name},
+            "spec": {},
+        },
+    )
+    campaign_edge_url = x.headers["Edges"]
+    campaign = x.json()
+
+    # create a trio of nodes for the campaign
+    for _ in range(3):
+        x = await aclient.post(
+            "/cm-service/v2/nodes",
+            json={
+                "apiVersion": "io.lsst.cmservice/v1",
+                "kind": "node",
+                "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+                "spec": {},
+            },
+        )
+        node = x.json()
+        node_ids.append(node["name"])
+
+    # Create edges between each campaign node with parallelization
+    _ = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+            "spec": {
+                "source": "START",
+                "target": node_ids[0],
+            },
+        },
+    )
+    _ = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+            "spec": {
+                "source": node_ids[0],
+                "target": node_ids[1],
+            },
+        },
+    )
+    _ = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+            "spec": {
+                "source": node_ids[0],
+                "target": node_ids[2],
+            },
+        },
+    )
+    _ = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+            "spec": {
+                "source": node_ids[1],
+                "target": "END",
+            },
+        },
+    )
+    _ = await aclient.post(
+        "/cm-service/v2/edges",
+        json={
+            "apiVersion": "io.lsst.cmservice/v1",
+            "kind": "edge",
+            "metadata": {"name": uuid4().hex[-8:], "namespace": campaign["id"]},
+            "spec": {
+                "source": node_ids[2],
+                "target": "END",
+            },
+        },
+    )
+    yield campaign_edge_url
+
+
+async def test_build_and_walk_graph(
+    aclient: AsyncClient, session: AnyAsyncSession, test_campaign: str
+) -> None:
+    """Test the generation and traversal of a campaign graph as created in the
+    ``test_campaign`` fixture.
+
+    Test that the graph is traversed from START to END in order, and that as
+    graph nodes are "processable" they can be handled. In this test, the status
+    of each node is set to "accepted" and updated in the databse. The campaign
+    graph is recreated between each stage of the mock graph processing.
+
+    The test campaign is a set of 3 nodes arranged in a graph:
+
+    ```
+    START --> A --> B --> END
+                --> C -->
+    ```
+    """
+    edge_list = [Edge.model_validate(edge) for edge in (await aclient.get(test_campaign)).json()]
+    graph = await graph_from_edge_list_v2(edge_list, Node, session)
+
+    # the START node should be the only processable Node
+    for node in processable_graph_nodes(graph):
+        assert node.name == "START"
+        assert node.status is StatusEnum.waiting
+        # Add the Node back to the session and update its status
+        session.add(node)
+        await session.refresh(node)
+        node.status = StatusEnum.accepted
+        await session.commit()
+
+    # Repeat the graph building and traversal, this time expecting a single
+    # node that is not "START"
+    graph = await graph_from_edge_list_v2(edge_list, Node, session)
+    for node in processable_graph_nodes(graph):
+        assert node.name != "START"
+        assert node.status is StatusEnum.waiting
+        # Add the Node back to the session and update its status
+        session.add(node)
+        await session.refresh(node)
+        node.status = StatusEnum.accepted
+        await session.commit()
+
+    # Repeat the graph building and traversal, this time expecting a pair of
+    # nodes processable in parallel
+    graph = await graph_from_edge_list_v2(edge_list, Node, session)
+    count = 0
+    for node in processable_graph_nodes(graph):
+        count += 1
+        assert node.name != "START"
+        assert node.status is StatusEnum.waiting
+        # Add the Node back to the session and update its status
+        session.add(node)
+        await session.refresh(node)
+        node.status = StatusEnum.accepted
+        await session.commit()
+    assert count == 2
+
+    # Finally, expect the END node
+    graph = await graph_from_edge_list_v2(edge_list, Node, session)
+    for node in processable_graph_nodes(graph):
+        assert node.name == "END"
+        assert node.status is StatusEnum.waiting
+        # Add the Node back to the session and update its status
+        session.add(node)
+        await session.refresh(node)
+        node.status = StatusEnum.accepted
+        await session.commit()
+
+
+def test_validate_graph() -> None:
+    """Test basic graph validation operations using a simple DAG."""
+    edge_list = [("A", "B"), ("B", "C"), ("C", "D"), ("C", "E"), ("D", "F"), ("E", "F")]
+
+    g = nx.DiGraph()
+    g.add_edges_from(edge_list)
+
+    # this is a valid graph
+    assert validate_graph(g, "A", "F")
+
+    # add a new parallel node with no path to sink
+    g.add_edge("C", "CC")
+    assert not validate_graph(g, "A", "F")
+
+    # create a cycle with the new node
+    g.add_edge("CC", "A")
+    assert not validate_graph(g, "A", "F")
+
+    # correct the path
+    g.remove_edge("CC", "A")
+    g.add_edge("CC", "F")
+    assert validate_graph(g, "A", "F")
+
+    # remove the edges from a node
+    g.remove_edge("CC", "F")
+    g.remove_edge("C", "CC")
+    # the graph is invalid because "CC" is now an isolate
+    assert not validate_graph(g, "A", "F")
+
+    # remove the unneeded node
+    g.remove_node("CC")
+    assert validate_graph(g, "A", "F")

--- a/tests/v2/test_manifest_routes.py
+++ b/tests/v2/test_manifest_routes.py
@@ -131,6 +131,13 @@ async def test_load_manifests(aclient: AsyncClient) -> None:
     assert len(manifests) == 3
     assert manifests[-1]["spec"]["one"] == 1
 
+    # Get all the loaded manifests from the campaign route
+    x = await aclient.get(f"/cm-service/v2/campaigns/{campaign_id}/manifests")
+    assert x.is_success
+    manifests = x.json()
+    assert len(manifests) == 2
+    assert manifests[-1]["spec"]["one"] == 1
+
 
 async def test_patch_manifest(aclient: AsyncClient) -> None:
     """Tests partial update of manifests and single resource retrieval."""

--- a/tests/v2/test_node_routes.py
+++ b/tests/v2/test_node_routes.py
@@ -1,0 +1,130 @@
+"""Tests v2 fastapi node routes"""
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+"""All tests in this module will run in the same event loop."""
+
+
+async def test_list_delete_no_nodes(aclient: AsyncClient) -> None:
+    """Tests listing nodes when there are no nodes available."""
+    x = await aclient.get("/cm-service/v2/nodes")
+    assert x.is_success
+    assert len(x.json()) == 0
+
+    x = await aclient.get(f"/cm-service/v2/nodes/{uuid4()}")
+    assert x.status_code == 404
+
+    # there is no delete api for nodes
+    x = await aclient.delete(f"/cm-service/v2/nodes/{uuid4()}")
+    assert x.status_code == 405
+
+
+async def test_node_negative(aclient: AsyncClient) -> None:
+    """Tests node route negative outcomes."""
+
+    # negative test: failing request model validation
+    x = await aclient.post(
+        "cm-service/v2/nodes",
+        json={
+            "kind": "no_such_kind",
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: using wrong manifest kind
+    x = await aclient.post(
+        "cm-service/v2/nodes",
+        json={
+            "kind": "other",
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: missing node name
+    x = await aclient.post(
+        "cm-service/v2/nodes",
+        json={
+            "kind": "node",
+            "metadata": {},
+            "spec": {},
+        },
+    )
+    assert x.is_client_error
+
+    # negative test: missing campaign namespace
+    x = await aclient.post(
+        "cm-service/v2/nodes",
+        json={
+            "kind": "node",
+            "metadata": {"name": uuid4().hex[8:]},
+            "spec": {},
+        },
+    )
+    assert x.is_client_error
+
+
+async def test_node_lifecycle(aclient: AsyncClient) -> None:
+    """Tests node lifecycle."""
+    campaign_name = uuid4().hex[:8]
+
+    # Create a campaign for edges. Campaigns come with START and END nodes.
+    x = await aclient.post(
+        "/cm-service/v2/campaigns",
+        json={
+            "kind": "campaign",
+            "metadata": {"name": campaign_name},
+            "spec": {},
+        },
+    )
+    assert x.is_success
+    campaign_id = x.json()["id"]
+
+    # Create a new campaign node
+    x = await aclient.post(
+        "/cm-service/v2/nodes",
+        json={
+            "kind": "node",
+            "metadata": {"name": uuid4().hex[8:], "namespace": campaign_id},
+            "spec": {
+                "handler": "lsst.cmservice.handlers.element_handler.ElementHandler",
+                "pipeline_yaml": "${DRP_PIPE_DIR}/pipelines/HSC/DRP-RC2.yaml#step1",
+                "query": [{"instrument": "HSC"}, {"skymap": "hsc_rings_v1"}],
+                "split": {
+                    "dataset": "raw",
+                    "field": "exposure",
+                    "method": "query",
+                    "minGroups": 3,
+                    "maxInFlight": 3,
+                },
+            },
+        },
+    )
+    assert x.is_success
+    node = x.json()
+    assert node["version"] == 1
+    node_url = x.headers["Self"]
+
+    # Edit a Node using RFC6902 json-patch
+    x = await aclient.patch(
+        node_url,
+        headers={"Content-Type": "application/json-patch+json"},
+        json=[
+            {"op": "replace", "path": "/configuration/split/maxInFlight", "value": 4},
+            {
+                "op": "add",
+                "path": "/configuration/query/-",
+                "value": {"dimension": "fact"},
+            },
+        ],
+    )
+    assert x.is_success
+    node = x.json()
+
+    # test that the updates have been made and the version has been bumped
+    assert node["configuration"]["split"]["maxInFlight"] == 4
+    assert node["configuration"]["query"][-1]["dimension"] == "fact"
+    assert node["version"] == 2


### PR DESCRIPTION
- adds CRUD routes for Node and Edge REST APIs to the v2 router
- adds functions supporting graph generation, validation, and traversal