### PR TITLE
DM-54233 - Implement Group Rescue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages for testing
-        run: uv sync --dev --frozen
+        run: uv sync --dev --all-packages --frozen
 
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ run: export DB__ECHO=true
 run: export FEATURE_API_V2=1
 run: export FEATURE_API_V1=0
 run: export FEATURE_DAEMON_V2=0
+run: export FEATURE_STORE_FSM=1
 run: run-compose
 	alembic upgrade head
 	python3 -m lsst.cmservice.main
@@ -140,6 +141,7 @@ run-worker: export FEATURE_DAEMON_V2=1
 run-worker: export FEATURE_DAEMON_CAMPAIGNS=1
 run-worker: export FEATURE_DAEMON_NODES=1
 run-worker: export FEATURE_ALLOW_TASK_UPSERT=1
+run-worker: export FEATURE_STORE_FSM=1
 run-worker: run-compose
 	alembic upgrade head
 	python3 -m lsst.cmservice.daemon
@@ -175,32 +177,3 @@ unmigrate: export DB__PASSWORD=INSECURE-PASSWORD
 unmigrate: export DB__URL=postgresql://${PGHOST}/${PGDATABASE}
 unmigrate: run-compose
 	alembic downgrade base
-
-
-#------------------------------------------------------------------------------
-# Targets for running per-developer service instances on USDF Rubin dev nodes,
-# using a single shared backend cnpg Postgres in the usdf-cm-dev k8s vcluster.
-# Currently used by most devs for development/debug, and also by pilots for
-# production runs.
-#
-# FIXME: TO BE DEPRECATED as soon as we can reliably use shared phalanx service
-# for production and sqlite for development/debug.
-#------------------------------------------------------------------------------
-
-.PHONY: run-usdf-dev
-run-usdf-dev:DB__HOST=$(shell kubectl --cluster=usdf-cm-dev -n cm-service get svc/cm-pg-lb -o jsonpath='{..ingress[0].ip}')'
-run-usdf-dev: export DB__URL=postgresql://cm-service@${DB__HOST}:5432/cm-service
-run-usdf-dev: export DB__PASSWORD=$(shell kubectl --cluster=usdf-cm-dev -n cm-service get secret/cm-pg-app -o jsonpath='{.data.password}' | base64 --decode)
-run-usdf-dev: export DB__ECHO=true
-run-usdf-dev:
-	python3 -m lsst.cmservice.main
-
-get-env-%: DB__HOST=$(shell kubectl --cluster=$* -n cm-service get svc/cm-pg-lb -o jsonpath='{..ingress[0].ip}')
-get-env-%: export DB__URL=postgresql://cm-servicer@${DB__HOST}:5432/cm-service
-get-env-%: export DB__PASSWORD=$(shell kubectl --cluster=$* -n cm-service get secret/cm-pg-app -o jsonpath='{.data.password}' | base64 --decode)
-get-env-%: export DB__ECHO=true
-get-env-%:
-	rm -f .env.$*
-	echo DB__URL=$${DB__URL} > .env.$*
-	echo DB__ECHO=$${DB__ECHO} >> .env.$*
-	echo DB__PASSWORD=$${DB__PASSWORD} >> .env.$*

--- a/alembic/seed/seed_ci_campaign.yaml
+++ b/alembic/seed/seed_ci_campaign.yaml
@@ -107,8 +107,8 @@ spec:
   environment:
     LSST_S3_USE_THREADS: "False"
     LSST_RESOURCES_EXECUTOR: "process"
-  extra_run_quantum_options: >-
-    --no-raise-on-partial-outputs
+  extra_run_quantum_options:
+    - --no-raise-on-partial-outputs
   # Multiple manifests can provide include_files; these are blended together
   # when the YAML template is rendered; e.g., Site-specific includes can be set on
   # a site manifest; wms-specific includes on a wms manifest.

--- a/packages/cm-models/src/lsst/cmservice/models/lib/graph.py
+++ b/packages/cm-models/src/lsst/cmservice/models/lib/graph.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Iterable, Mapping, MutableSet, Sequence
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 from uuid import UUID, uuid4, uuid5
 
 import networkx as nx
@@ -92,14 +94,25 @@ async def graph_from_edge_list_v2(
     return g
 
 
-def subgraph_between_nodes(g: nx.Graph, source: UUID, sink: UUID) -> nx.Graph:
+def subgraph_between_nodes(g: nx.DiGraph[UUID], source: UUID, sink: UUID) -> nx.DiGraph[UUID]:
     """Determine subgraph of graph ``g`` based on an arbitrary source and sink
     node in the graph. If no such subgraph exists, returns an empty graph.
     """
     nodes = set()
     for path in nx.all_simple_paths(g, source=source, target=sink):
         nodes.update(path)
-    return g.subgraph(nodes)
+    return cast(nx.DiGraph, g.subgraph(nodes))
+
+
+def topographical_sorted_collections(g: nx.DiGraph[UUID]) -> list[str]:
+    """Returns a topologically sorted list of run collections for Group nodes
+    in a graph `g`.
+    """
+    return [
+        g.nodes[group]["model"].configuration["butler"]["collections"]["group_output"]
+        for group in nx.topological_sort(g)
+        if g.nodes[group]["model"].kind is ManifestKind.group
+    ]
 
 
 def find_endpoints_in_directed_graph(g: nx.DiGraph) -> tuple[UUID, UUID]:

--- a/packages/cm-models/src/lsst/cmservice/models/lib/graph.py
+++ b/packages/cm-models/src/lsst/cmservice/models/lib/graph.py
@@ -10,7 +10,7 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from lsst.cmservice.models.db.campaigns import Edge, Node
-from lsst.cmservice.models.enums import ManifestKind
+from lsst.cmservice.models.enums import ManifestKind, StatusEnum
 from lsst.cmservice.models.lib.timestamp import element_time
 from lsst.cmservice.models.types import AnyAsyncSession
 
@@ -104,14 +104,34 @@ def subgraph_between_nodes(g: nx.DiGraph[UUID], source: UUID, sink: UUID) -> nx.
     return cast(nx.DiGraph, g.subgraph(nodes))
 
 
-def topographical_sorted_collections(g: nx.DiGraph[UUID]) -> list[str]:
+def topographical_sorted_collections(g: nx.DiGraph[UUID], *, reverse: bool = False) -> list[str]:
     """Returns a topologically sorted list of run collections for Group nodes
     in a graph `g`.
+
+    This function is primarily used by Collect nodes at the sink of a step's
+    subgraph of group nodes, so it is assumed that the reachability of that
+    Collect node is dependent on the successful state of its ancestors. There-
+    fore, every Group node in the (sub)graph is included in the list of sorted
+    collections if its state is `accepted`, allowing the exclusion of any other
+    terminal state that has otherwise allowed the Daemon to continue graph
+    evolution.
+
+    Parameters
+    ----------
+    g: nx.DiGraph[UUID]
+        A directed graph whose node identifiers are UUIDs. It is expected that
+        the graph has been constructed using the `model` node view.
+
+    reverse: bool
+        Whether to reverse the graph before sorting. This may be used to get
+        a "backward" view of the nodes.
     """
+    _g: nx.DiGraph[UUID] = nx.reverse_view(g) if reverse else g  # type: ignore[type-var]
     return [
-        g.nodes[group]["model"].configuration["butler"]["collections"]["group_output"]
-        for group in nx.topological_sort(g)
+        g.nodes[group]["model"].configuration["butler"]["collections"]["run"]
+        for group in nx.topological_sort(_g)
         if g.nodes[group]["model"].kind is ManifestKind.group
+        and g.nodes[group]["model"].status is StatusEnum.accepted
     ]
 
 
@@ -268,7 +288,7 @@ def processable_graph_nodes(g: nx.DiGraph) -> Iterable[Node]:
                 processable_nodes.add(node)
                 # We found a processable node in this path, stop traversal
                 break
-            elif node.status.is_bad():
+            elif node.status is StatusEnum.failed:
                 # We reached a failed node in this path, it is blocked
                 break
             else:

--- a/packages/cm-models/src/lsst/cmservice/models/manifests/bps.py
+++ b/packages/cm-models/src/lsst/cmservice/models/manifests/bps.py
@@ -160,7 +160,7 @@ class BpsSpec(ManifestSpec):
     ) = None
 
     extra_init_options: (
-        Annotated[str, Field(description="Passthrough options added to the end of pipetaskinit")]
+        Annotated[list[str], Field(description="Passthrough options added to the end of pipetaskinit")]
         | Annotated[
             None,
             Field(
@@ -171,7 +171,7 @@ class BpsSpec(ManifestSpec):
     ) = None
 
     extra_qgraph_options: (
-        Annotated[str, Field(description="Passthrough options for QuantumGraph builder.")]
+        Annotated[list[str], Field(description="Passthrough options for QuantumGraph builder.")]
         | Annotated[
             None,
             Field(
@@ -183,7 +183,8 @@ class BpsSpec(ManifestSpec):
 
     extra_run_quantum_options: (
         Annotated[
-            str, Field(description="Passthrough options for Quantum execution", examples=["--no-versions"])
+            list[str],
+            Field(description="Passthrough options for Quantum execution", examples=["--no-versions"]),
         ]
         | Annotated[
             None,
@@ -195,7 +196,7 @@ class BpsSpec(ManifestSpec):
     ) = None
 
     extra_update_qgraph_options: (
-        Annotated[str, Field(description="Passthrough options for QuantumGraph updater.")]
+        Annotated[list[str], Field(description="Passthrough options for QuantumGraph updater.")]
         | Annotated[
             None,
             Field(

--- a/packages/cm-models/src/lsst/cmservice/models/templates/bps_submit_yaml.j2
+++ b/packages/cm-models/src/lsst/cmservice/models/templates/bps_submit_yaml.j2
@@ -60,16 +60,16 @@ payload:
   {{ key }}: "{{ value | trim }}"
 {%- endfor %}
 {%- if bps.extra_qgraph_options %}
-extraQgraphOptions: {{ bps.extra_qgraph_options | replace("\n", " ") | trim }}
+extraQgraphOptions: {{ bps.extra_qgraph_options | join(" ")}}
 {%- endif %}
 {%- if bps.extra_run_quantum_options %}
-extraRunQuantumOptions: {{ bps.extra_run_quantum_options | replace("\n", " ") | trim }}
+extraRunQuantumOptions: {{ bps.extra_run_quantum_options | join(" ") }}
 {%- endif %}
 {%- if bps.extra_init_options %}
-extraInitOptions: {{ bps.extra_init_options | replace("\n", " ") | trim }}
+extraInitOptions: {{ bps.extra_init_options | join(" ") }}
 {%- endif %}
 {%- if bps.extra_update_qgraph_options %}
-extraUpdateQgraphOptions: {{ bps.extra_update_qgraph_options | replace("\n", " ") | trim }}
+extraUpdateQgraphOptions: {{ bps.extra_update_qgraph_options | join(" ") }}
 {%- endif %}
 {# BLANK LINE #}
 {%- if bps.clustering %}

--- a/packages/cm-web/pyproject.toml
+++ b/packages/cm-web/pyproject.toml
@@ -6,7 +6,8 @@ requires-python = ">=3.12,<3.14"
 dependencies = [
     "deepdiff>=8.6.1",
     "networkx>=3.5",
-    "nicegui>=3.8.0",
+    "nicegui>=3.11.0",
+    "nice-dialog",
     "pydantic>=2.12",
     "pydantic-extra-types>=2.10.5",
     "pydantic-settings>=2.12",
@@ -38,3 +39,4 @@ path = "src/lsst/cmservice/web/__init__.py"
 
 [tool.uv.sources]
 lsst-cmservice-models = { workspace = true }
+nice-dialog = { git = "https://github.com/tcjennings/nice-dialogs", rev = "ac9bce6de5604837e80a921206cf71d5a2e10010" }

--- a/packages/cm-web/pyproject.toml
+++ b/packages/cm-web/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "deepdiff>=8.6.1",
     "networkx>=3.5",
     "nicegui>=3.11.0",
-    "nice-dialog",
+    "nice-dialogs",
     "pydantic>=2.12",
     "pydantic-extra-types>=2.10.5",
     "pydantic-settings>=2.12",
@@ -39,4 +39,4 @@ path = "src/lsst/cmservice/web/__init__.py"
 
 [tool.uv.sources]
 lsst-cmservice-models = { workspace = true }
-nice-dialog = { git = "https://github.com/tcjennings/nice-dialogs", rev = "ac9bce6de5604837e80a921206cf71d5a2e10010" }
+nice-dialogs = { git = "https://github.com/tcjennings/nice-dialogs", rev = "0beec0651fa101576741d2a8cdf7ec5e7c961d59" }

--- a/packages/cm-web/src/lsst/cmservice/web/api/__init__.py
+++ b/packages/cm-web/src/lsst/cmservice/web/api/__init__.py
@@ -15,6 +15,7 @@ from .nodes import (
     node_activity_logs,
     retry_restart_node,
 )
+from .rescue import rescue_group
 
 __all__ = [
     "insert_or_append_node",
@@ -29,6 +30,7 @@ __all__ = [
     "node_activity_logs",
     "put_manifest_list",
     "put_one_manifest",
+    "rescue_group",
     "retry_restart_node",
     "toggle_campaign_state",
     "wait_for_activity_to_complete",

--- a/packages/cm-web/src/lsst/cmservice/web/api/campaigns.py
+++ b/packages/cm-web/src/lsst/cmservice/web/api/campaigns.py
@@ -1,5 +1,7 @@
 import asyncio
 from collections.abc import AsyncGenerator, Sequence
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 from httpx import AsyncClient
 from nicegui import app, ui
@@ -127,11 +129,21 @@ async def compile_campaign_manifests(campaign_id: str | None = None, manifests: 
                     ).props("style: flat").tooltip("Edit Manifest Configuration")
 
 
-async def toggle_campaign_state(e: ValueChangeEventArguments, campaign: dict) -> None:
+async def toggle_campaign_state(e: ValueChangeEventArguments | SimpleNamespace, campaign: dict) -> None:
     """Toggles a campaign between the PAUSED and RUNNING states by affecting
     a PATCH call to the campaign API.
+
+    Parameters
+    ----------
+    e: ValueChangeEventArguments | SimpleNamespace
+        When called by a NiceGUI element (e.g., `ui.switch`), we receive the
+        event associated with an action. Alternately, a `SimpleNamespace` can
+        approximate the event as long as the correct attribute is set.
     """
-    campaign_name = campaign["name"]
+    if TYPE_CHECKING:
+        e = cast(ValueChangeEventArguments, e)
+    update_complete = asyncio.Event()
+    campaign_name = campaign.get("name", "")
     campaign_id = campaign["id"]
     n = ui.notification(timeout=None)
 
@@ -143,33 +155,55 @@ async def toggle_campaign_state(e: ValueChangeEventArguments, campaign: dict) ->
         new_status = "paused"
 
     async with CLIENT_FACTORY.aclient() as aclient:
-        r = await aclient.patch(
-            f"/campaigns/{campaign_id}",
-            json={"status": new_status},
-            headers={"Content-Type": "application/merge-patch+json"},
-        )
+        r = await aclient.get(f"/campaigns/{campaign_id}")
         r.raise_for_status()
-        status_url = r.headers["StatusUpdate"]
+        current_status = r.json()["status"]
+        status_url: str | None = None
+        is_error = False
+        error_str = ""
+
+        # Fail fast if this is going to be a no-op
+        if current_status == new_status:
+            update_complete.set()
+        else:
+            r = await aclient.patch(
+                f"/campaigns/{campaign_id}",
+                json={"status": new_status},
+                headers={"Content-Type": "application/merge-patch+json"},
+            )
+            r.raise_for_status()
+            status_url = r.headers.get("StatusUpdate", None)
 
         activity_log: list = []
         for _ in range(10):
             n.spinner = True
+            if update_complete.is_set():
+                break
+            elif not status_url:
+                is_error = True
+                error_str = "No status update URL received."
+                break
             r = await aclient.get(status_url)
             if r.is_success:
                 activity_log.extend(r.json())
                 if len(activity_log):
-                    break
+                    update_complete.set()
+            is_error = r.is_error
             await asyncio.sleep(1.0)
 
-    error = r.is_error or activity_log[0].get("detail", {}).get("error", None)
+        if activity_log:
+            is_error = activity_log[0].get("detail", {}).get("error", None)
+
     n.spinner = False
-    if error:
+    if is_error:
         n.color = "negative"
-        message = f"Failed to set {campaign_name} to {new_status}: {error}"
+        message = f"Failed to set {campaign_name} to {new_status}: {error_str}"
         n.message = message
         n.close_button = True
     else:
         app.storage.client["state"].campaigns[campaign_id]["status"] = new_status
         n.color = "positive"
         n.message = f"{campaign_name} is now {new_status}"
-        n.timeout = 3.0
+        n.position = "top"
+        n.close_button = "OK"
+        n.close_button = True

--- a/packages/cm-web/src/lsst/cmservice/web/api/manifests.py
+++ b/packages/cm-web/src/lsst/cmservice/web/api/manifests.py
@@ -29,6 +29,7 @@ async def get_one_manifest(
         return r
 
 
+# FIXME this function is badly named
 async def put_one_manifest(manifest_id: str, manifest_name: str, to_namespace: str) -> Response:
     """Copies a manifest into the designated target namespace."""
     url = f"/manifests/{manifest_id}"
@@ -51,6 +52,7 @@ async def put_manifest_list(manifests: list[dict]) -> bool:
     only ordering necessary is that "campaigns" must be first in the list in
     order to prepare any target namespaces for subsequent manifests.
     """
+    # TODO this should probably return a list of IDs for the added manifests
     # TODO sort manifests list by kind, campaigns first.
     async with CLIENT_FACTORY.aclient() as client:
         for manifest in manifests:

--- a/packages/cm-web/src/lsst/cmservice/web/api/nodes.py
+++ b/packages/cm-web/src/lsst/cmservice/web/api/nodes.py
@@ -124,8 +124,15 @@ async def fast_forward_node(n0: str) -> None:
         node_cache[n0]["icon"] = "fast_forward"
 
 
+# FIXME rename function to better reflect its multipurpose utility
 async def retry_restart_node(
-    n0: str, *, force: bool = False, reset: bool = False, accept: bool = False, reject: bool = False
+    n0: str,
+    *,
+    force: bool = False,
+    reset: bool = False,
+    accept: bool = False,
+    reject: bool = False,
+    fail: bool = False,
 ) -> None:
     """A group node in a failed state can be "restarted" if the BPS milestone
     is reached, i.e., a submit directory has been discovered and a qg file
@@ -151,18 +158,25 @@ async def retry_restart_node(
         be set.
 
     reject : bool
+        If True, the node is unconditionally rejected, but ``force`` must also
+        be set.
+
+    fail: bool
         If True, the node is unconditionally failed, but ``force`` must also
         be set.
     """
     # TODO refactor these parameters into a FlagEnum
     url = f"/nodes/{n0}"
-    retry_or_restart = "Restarting" if force else "Retrying"
-    retry_or_restart = "Resetting" if reset else retry_or_restart
-    retry_or_restart = "Accepting" if all([force, accept]) else retry_or_restart
-    retry_or_restart = "Rejecting" if all([force, reject]) else retry_or_restart
     target_state = "waiting" if reset else "ready"
     target_state = "accepted" if all([force, accept]) else target_state
-    target_state = "failed" if all([force, reject]) else target_state
+    target_state = "failed" if all([force, fail]) else target_state
+    target_state = "rejected" if all([force, reject]) else target_state
+
+    message_verb = "Restarting" if force else "Retrying"
+    message_verb = "Resetting" if reset else message_verb
+    message_verb = "Accepting" if all([force, accept]) else message_verb
+    message_verb = "Rejecting" if all([force, reject]) else message_verb
+    message_verb = "Failing" if all([force, fail]) else message_verb
 
     async with CLIENT_FACTORY.aclient() as client:
         n = ui.notification(timeout=None)
@@ -175,7 +189,7 @@ async def retry_restart_node(
             r.raise_for_status()
             n.spinner = True
             n.type = "ongoing"
-            n.message = f"{retry_or_restart} node..."
+            n.message = f"{message_verb} node..."
         except HTTPStatusError as e:
             n.type = "negative"
             n.timeout = 5.0

--- a/packages/cm-web/src/lsst/cmservice/web/api/rescue.py
+++ b/packages/cm-web/src/lsst/cmservice/web/api/rescue.py
@@ -1,0 +1,152 @@
+r"""
+
+Rescue GROUP operation is a chain of api calls to
+
+1. PAUSE campaign for updates
+
+2. mark a failed GROUP or RESCUE "accepted"
+
+3. create a new RESCUE node in the campaign.
+
+    - RESCUE == GROUP or previous RESCUE with config change (bps option)
+    - extra-qgraph-options: --skip-existing-in ...
+
+4. ADD NEW GROUP to graph after RESCUED NODE
+
+The collection list for "skip-existing-in" is the comma-separated list of any
+preceeding groups in the rescue chain:
+
+STEP -> GROUP -> RESCUE -> [RESCUE ->] COLLECT
+        ^^^^^    ^^^^^^     ^^^^^^
+        \________skips in
+         \______________\___skips in
+
+Notes
+-----
+- The configuration for a group is the completely baked configuration chain, so
+  additional manifest lookups should not be necessary.
+- The "trailing" run collection should therefore be part of the configuration
+  of the GROUP or RESCUE being rescued.
+- In case of a RESCUE chain, the bps option just keeps getting longer, with the
+  latest run collection appended to the list of collections.
+
+Double Check
+------------
+- [ ] The API allows creation of new GROUP nodes.
+- [ ] Should the action be performed on a FAILED group, with marking acceptance
+      part of the workflow, or only available on ACCEPTED groups, irrespective
+      of how they got that way?
+"""
+
+import re
+from types import SimpleNamespace
+from typing import cast
+
+from httpx import HTTPStatusError
+from nicegui.events import ValueChangeEventArguments
+
+from lsst.cmservice.models.db.campaigns import Node
+
+from ..lib.models import STEP_MANIFEST_TEMPLATE
+from .campaigns import toggle_campaign_state
+from .manifests import put_manifest_list
+from .nodes import get_one_node, insert_or_append_node, retry_restart_node
+
+
+async def rescue_group(n0: str) -> str:
+    """Performs a rescue workflow for a failed group.
+
+    This workflow uses prescribed API operation primitives from other workflows
+    so does not access an HTTP client through dependency injection or factory
+    functions; client management is handled within the other primitives.
+
+    Returns
+    -------
+    str
+        The string UUID of the new rescue group
+    """
+    try:
+        # Since we have only the group ID, fetch the entire Group object from
+        # the API and extract its parent campaign.
+        if (r := await get_one_node(id=n0, namespace=None)) is not None:
+            node = Node.model_validate_json(r.content)
+            # Pause the campaign
+            campaign_id: str = str(node.namespace)
+        else:
+            raise RuntimeError("Could not obtain node and/or campaign information for group")
+        e = cast(ValueChangeEventArguments, SimpleNamespace(value=False))
+        await toggle_campaign_state(e, {"id": campaign_id})
+
+    except (RuntimeError, HTTPStatusError) as e:
+        raise RuntimeError("Could not retrieve target Node") from e
+
+    # Identify the trailing collections with the partial work
+    group_output = node.configuration["butler"]["collections"].pop("group_output")
+    group_run = node.configuration["butler"]["collections"].pop("run")
+
+    # for the bps option, we locate the `extra_qgraph_options` param
+    extra_qgraph_options: list[str] = node.configuration.get("bps", {}).get("extra_qgraph_options", [])
+
+    # Locate any existing `skip-existing-in` option in the param list
+    option_stem = "--skip-existing-in"
+    pattern = re.compile(rf"^{option_stem}\s+(?P<collections>\S+)$")
+    found_option = False
+
+    for i, opt in enumerate(extra_qgraph_options):
+        m = pattern.match(opt)
+        if m:
+            # Update the existing option
+            skipped_collections: list[str] = m.group("collections").split(",")
+            skipped_collections.append(group_run)
+            extra_qgraph_options[i] = f"{option_stem} {','.join(skipped_collections)}"
+            found_option = True
+
+    if not found_option:
+        # Add a new option
+        extra_qgraph_options.append(f"{option_stem} {group_run}")
+
+    # Update the Node configuration to reflect a Rescue operation
+    rescue_count: int = node.metadata_.get("rescues", 0) + 1
+    rescue_name = f"{node.name}_rescue_{rescue_count}"
+
+    # Apply the updated bps options in the new rescue group
+    node.configuration["bps"]["extra_qgraph_options"] = extra_qgraph_options
+
+    collections: dict = node.configuration["butler"].pop("collections", {})
+    # change butler.collections.group_output to `*/rescue_NNN`
+    collections["group_output"] = f"{group_output}/rescue_{rescue_count:03d}"
+    # change butler.collections.run to `*/rescue_NNN_version_Y`
+    collections["run"] = f"{group_run}/rescue_{rescue_count:03d}"
+    node.configuration["butler"]["collections"] = collections
+
+    # NOTE unlike group nodes created during step preparation, the ID generated
+    # for this rescue group will be performed by the API like other nodes.
+    rescue_manifest = STEP_MANIFEST_TEMPLATE | {
+        "spec": node.configuration,
+        "metadata": {
+            "name": rescue_name,
+            "namespace": campaign_id,
+            "kind": "group",
+            "version": 0,
+            "rescues": rescue_count,
+        },
+    }
+
+    # put the rescue group into the campaign
+    try:
+        if await put_manifest_list([rescue_manifest]):
+            # fetch the new rescue group
+            if (r := await get_one_node(id=rescue_name, namespace=campaign_id)) is None:
+                raise RuntimeError("Failed to fetch new rescue group node")
+            rescue: dict = r.json()
+        else:
+            raise RuntimeError("Failed to create new rescue group node")
+
+        # put the rescue group into the graph (insert)
+        await insert_or_append_node(n0=n0, n1=rescue["id"], namespace=campaign_id, operation="insert")
+
+        # Force-accept the failed group because it did partial work
+        await retry_restart_node(n0=n0, force=True, accept=True)
+        return rescue["id"]
+    except (HTTPStatusError, RuntimeError) as e:
+        raise RuntimeError("Failed to create or retrieve new rescue group node") from e

--- a/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
+++ b/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
@@ -56,6 +56,7 @@ class NodeRecoverAction(Enum):
     retry = auto()
     reset = auto()
     force = auto()
+    rescue = auto()
 
 
 class NodeAllowedActions(IntFlag):
@@ -68,6 +69,7 @@ class NodeAllowedActions(IntFlag):
     retry = auto()
     reset = auto()
     force = auto()
+    rescue = auto()
 
     @classmethod
     def all(cls) -> Self:
@@ -113,6 +115,13 @@ class NodeRecoveryPopup(ui.dialog):
                         color="warning",
                         on_click=lambda: self.submit(NodeRecoverAction.force),
                     ).tooltip(strings.NODE_FORCE_TOOLTIP)
+                if NodeAllowedActions.rescue in allowed_actions:
+                    ui.chip(
+                        "rescue",
+                        icon="fire_truck",
+                        color="warning",
+                        on_click=lambda: self.submit(NodeRecoverAction.rescue),
+                    ).tooltip(strings.NODE_RESCUE_TOOLTIP)
                 ui.chip(
                     "cancel",
                     icon="cancel",
@@ -134,6 +143,7 @@ class NodeRecoveryPopup(ui.dialog):
             allowed_actions = NodeAllowedActions.force
         elif node["kind"] != "group":
             allowed_actions &= ~NodeAllowedActions.restart
+            allowed_actions &= ~NodeAllowedActions.rescue
         result = await cls(allowed_actions)
 
         match result:
@@ -145,6 +155,8 @@ class NodeRecoveryPopup(ui.dialog):
                 await api.retry_restart_node(n0=node["id"], force=True, reset=True)
             case NodeRecoverAction.force:
                 await api.retry_restart_node(n0=node["id"], force=True, accept=True)
+            case NodeRecoverAction.rescue:
+                await api.rescue_group(n0=node["id"])
             case _:
                 # including the cancel case
                 call_refreshable = False

--- a/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
+++ b/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
@@ -1,12 +1,13 @@
 """Module implementing reusable and/or modular Dialogs."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum, IntFlag, auto
 from typing import TYPE_CHECKING, Any, Self
 
 import yaml
+from nice_dialog.dialogs.confirmation import ConfirmationDialog
 from nicegui import ui
 from nicegui.events import ClickEventArguments, GenericEventArguments, ValueChangeEventArguments
 from pydantic_core import ValidationError
@@ -85,49 +86,85 @@ class NodeRecoveryPopup(ui.dialog):
     def __init__(self, allowed_actions: NodeAllowedActions) -> None:
         super().__init__()
         with self, ui.card():
-            ui.label(strings.NODE_RECOVERY_DIALOG_LABEL)
-            with ui.row():
+            ui.label(strings.NODE_RECOVERY_DIALOG_LABEL).classes("font-bold text-3xl")
+            with ui.row().classes("w-full flex items-center"):
                 if NodeAllowedActions.restart in allowed_actions:
                     ui.chip(
                         "restart",
                         icon="restart_alt",
-                        color="positive",
-                        on_click=lambda: self.submit(NodeRecoverAction.restart),
+                        color="green",
+                        text_color="white",
+                        on_click=lambda: self.confirm_and_submit(NodeRecoverAction.restart),
                     ).tooltip(strings.NODE_RESTART_TOOLTIP)
                 if NodeAllowedActions.retry in allowed_actions:
                     ui.chip(
                         "retry",
                         icon="replay",
-                        color="accent",
-                        on_click=lambda: self.submit(NodeRecoverAction.retry),
+                        color="violet",
+                        text_color="white",
+                        on_click=lambda: self.confirm_and_submit(NodeRecoverAction.retry),
                     ).tooltip(strings.NODE_RETRY_TOOLTIP)
                 if NodeAllowedActions.reset in allowed_actions:
                     ui.chip(
                         "reset",
                         icon="settings_backup_restore",
-                        color="negative",
-                        on_click=lambda: self.submit(NodeRecoverAction.reset),
+                        color="indigo",
+                        text_color="white",
+                        on_click=lambda: self.confirm_and_submit(NodeRecoverAction.reset),
                     ).tooltip(strings.NODE_RESET_TOOLTIP)
-                if NodeAllowedActions.force in allowed_actions:
-                    ui.chip(
-                        "accept",
-                        icon="auto_fix_high",
-                        color="warning",
-                        on_click=lambda: self.submit(NodeRecoverAction.force),
-                    ).tooltip(strings.NODE_FORCE_TOOLTIP)
                 if NodeAllowedActions.rescue in allowed_actions:
                     ui.chip(
                         "rescue",
                         icon="fire_truck",
-                        color="warning",
-                        on_click=lambda: self.submit(NodeRecoverAction.rescue),
+                        color="deepred",
+                        text_color="white",
+                        on_click=lambda: self.confirm_and_submit(NodeRecoverAction.rescue),
                     ).tooltip(strings.NODE_RESCUE_TOOLTIP)
-                ui.chip(
+            with ui.card_actions().classes("w-full align-right"):
+                if NodeAllowedActions.force in allowed_actions:
+                    ui.button(
+                        "accept",
+                        icon="auto_fix_high",
+                        color="deepgreen",
+                        on_click=lambda: self.confirm_and_submit(NodeRecoverAction.force),
+                    ).tooltip(strings.NODE_FORCE_TOOLTIP).props("flat")
+                ui.space()
+                ui.button(
                     "cancel",
                     icon="cancel",
                     color="negative",
                     on_click=lambda: self.submit(NodeRecoverAction.cancel),
-                ).tooltip("Never mind.")
+                ).tooltip("Never mind.").props("flat")
+
+    if TYPE_CHECKING:
+
+        def __await__(self) -> Generator[None, None, NodeRecoverAction]: ...
+
+    async def confirm_and_submit(self, action: NodeRecoverAction) -> None:
+        """A recover action confirmation prompt"""
+        confirm_text: str
+        match action:
+            case NodeRecoverAction.rescue:
+                confirm_text = strings.NODE_RESCUE_CONFIRMATION_DETAIL
+            case NodeRecoverAction.restart:
+                confirm_text = strings.NODE_RESTART_CONFIRMATION_DETAIL
+            case NodeRecoverAction.reset:
+                confirm_text = strings.NODE_RESET_CONFIRMATION_DETAIL
+            case NodeRecoverAction.retry:
+                confirm_text = strings.NODE_RETRY_CONFIRMATION_DETAIL
+            case NodeRecoverAction.force:
+                confirm_text = strings.NODE_FORCE_CONFIRMATION_DETAIL
+            case _:
+                confirm_text = "Are you sure?"
+        confirm = ConfirmationDialog(
+            message=confirm_text,
+            yes_return_value=action,
+            no_return_value=NodeRecoverAction.cancel,
+            show_remember_checkbox=False,
+        )
+        result, _ = await confirm
+        confirm.clear()
+        self.submit(result)
 
     @classmethod
     async def click(cls, e: GenericEventArguments, node: dict, refreshable: Callable) -> None:
@@ -205,6 +242,10 @@ class EditorDialog(ui.dialog):
 
         self.dialog_content(title)
 
+    if TYPE_CHECKING:
+
+        def __await__(self) -> Generator[None, None, MaybeDict]: ...
+
     def dialog_content(self, title: str) -> None:
         """Method creates core dialog components."""
         with (
@@ -236,7 +277,6 @@ class EditorDialog(ui.dialog):
                     ui.icon("help", color="info").classes("bg-white rounded-full p-1").tooltip(
                         "Drag for help"
                     )
-
             self.action_section()
 
     def ribbon(self) -> None:
@@ -384,6 +424,8 @@ class EditorDialog(ui.dialog):
         """Toggles the help pane to 50% if it's mostly closed already, other-
         wise closes the pane.
         """
+        if TYPE_CHECKING:
+            assert self.splitter.value is not None
         if self.splitter.value > 85:
             self.splitter.value = 50
         else:
@@ -512,7 +554,7 @@ class EditorDialog(ui.dialog):
         logic. This pattern can be used directly in pages that need to use a
         dialog.
         """
-        result: MaybeDict = await cls(ctx=ctx, title=title)
+        result = await cls(ctx=ctx, title=title)
 
         if result is not None and ctx.callback is not None:
             callback_result: MaybeDict | Awaitable[MaybeDict] = ctx.callback(result)

--- a/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
+++ b/packages/cm-web/src/lsst/cmservice/web/components/dialog.py
@@ -7,7 +7,7 @@ from enum import Enum, IntFlag, auto
 from typing import TYPE_CHECKING, Any, Self
 
 import yaml
-from nice_dialog.dialogs.confirmation import ConfirmationDialog
+from nice_dialogs.dialogs import ConfirmationDialog
 from nicegui import ui
 from nicegui.events import ClickEventArguments, GenericEventArguments, ValueChangeEventArguments
 from pydantic_core import ValidationError

--- a/packages/cm-web/src/lsst/cmservice/web/components/strings.py
+++ b/packages/cm-web/src/lsst/cmservice/web/components/strings.py
@@ -4,6 +4,7 @@ NODE_RESTART_TOOLTIP = """Attempt a BPS Restart of a Failed Group"""
 NODE_RETRY_TOOLTIP = """Attempt a new BPS Submit of a Failed Group"""
 NODE_RESET_TOOLTIP = """Completely reset the Node to the beginning"""
 NODE_FORCE_TOOLTIP = """Unconditionally accept the Node irrespective of its failure"""
+NODE_RESCUE_TOOLTIP = """Accept this Group and create a new Rescue Group in the graph"""
 
 LIBRARY_MANIFEST_TOOLIP = (
     """Library manifests are read-only global configuration documents that provide defaults for campaigns"""

--- a/packages/cm-web/src/lsst/cmservice/web/components/strings.py
+++ b/packages/cm-web/src/lsst/cmservice/web/components/strings.py
@@ -12,3 +12,47 @@ LIBRARY_MANIFEST_TOOLIP = (
 CAMPAIGN_MANIFEST_TOOLTIP = """Campaign manifests are versioned configuration documents for a campaign"""
 BREAKPOINT_ACCEPT_TOOLTIP = """Accept the campaign at the breakpoint and continue processing"""
 BREAKPOINT_REJECT_TOOLTIP = """Reject the campaign at the breakpoint and stop processing"""
+
+NODE_RESTART_CONFIRMATION_DETAIL = """\
+    This action will attempt a BPS restart operation on the failed node.
+    This will not change the configuration used by the attempt. This action is only available when a BPS
+    submit directory and QGraph file is available.
+    """
+NODE_RETRY_CONFIRMATION_DETAIL = """\
+    This action will attempt to execute the node's payload without making any changes to the configuration
+    or prepared artifacts.
+    """
+NODE_RESET_CONFIRMATION_DETAIL = """\
+    This action is "nuclear" -- all generated configuration and artifacts for the failed Node are removed, and
+    the state set back to a clean beginning. This does not determine or verify whether any data products or
+    collections were created, nor does it attempt to delete any data products or collections.
+    """
+NODE_RESCUE_CONFIRMATION_DETAIL = """\
+    This action will try to rescue a failed group by creating a clone of this group in the campaign graph.
+    The clone copy will use a new output and run collection, and its BPS configuration will be
+    set to "skip-existing-in" this failed group's run collection.
+    The failed group will be forced into an accepted state, ignoring any error conditions. If you want to
+    exclude the failed group's run collection from future collection chains, you must manually "reject" the
+    group. After a rescue, the campaign will remain in a paused state to allow you time to edit the clone
+    rescue group's configuration.
+    """
+NODE_FORCE_CONFIRMATION_DETAIL = """\
+    This action will ignore any failure states and mark the node as "accepted".
+    If this node is a Group, any partial outputs in its run collection will be included in the step output.
+    If no run collection exists, this can cause an error later when creating collection chains.
+    """
+
+GROUP_TOGGLE_REJECT_DETAIL = """\
+    Rejecting a Group means that for campaign evolution purposes, the
+    group is "successful" but its run collection will be excluded from
+    any step outputs.
+
+    Are you sure you want to reject this Group?
+    """
+GROUP_TOGGLE_ACCEPT_DETAIL = """\
+    Accepting a Group means that irrespective of any failures or
+    partial results, the Group's run collection will be included with
+    any step outputs.
+
+    Are you sure you want to accept this Group?
+"""

--- a/packages/cm-web/src/lsst/cmservice/web/pages/campaign_detail.py
+++ b/packages/cm-web/src/lsst/cmservice/web/pages/campaign_detail.py
@@ -390,7 +390,7 @@ class CampaignDetailPage(CMPage[CampaignDetailPageModel]):
         gauge_card_classes = "w-22 h-30 pt-[0.5rem] pb-[0.5rem] items-center"
         with ui.row().classes("w-full ml-4 mr-4 items-center") as self.gauges_row:
             with ui.card().classes(gauge_card_classes):
-                self.campaign_status_decorator()
+                ui.icon(StatusDecorators["running"].emoji, size="xl", color="primary")
                 with ui.row():
                     campaign_running = self.model["campaign"]["status"] == "running"
                     campaign_terminal: bool = self.model["campaign"]["status"] in (
@@ -417,15 +417,6 @@ class CampaignDetailPage(CMPage[CampaignDetailPageModel]):
                     log_count = len(self.model["logs"])
                     error_count = len([log for log in self.model["logs"] if log["detail"].get("error", None)])
                     ui.circular_progress(value=error_count, max=log_count, color="negative", size="xl")
-
-    def campaign_status_decorator(self) -> None:
-        """An icon representing the campaign state."""
-        ui.icon("", size="xl", color="primary").bind_name_from(
-            app.storage.client["state"].campaigns[self.campaign_id],
-            "status",
-            backward=lambda s: StatusDecorators[s].emoji,
-            strict=False,
-        )
 
     @ui.refreshable_method
     async def manifest_row(self, *, library: bool = False) -> None:

--- a/packages/cm-web/src/lsst/cmservice/web/pages/campaign_detail.py
+++ b/packages/cm-web/src/lsst/cmservice/web/pages/campaign_detail.py
@@ -568,7 +568,7 @@ class CampaignDetailPage(CMPage[CampaignDetailPageModel]):
             title=f"Editing Step {node_name}",
             initial_model=node_manifest,
         )
-        result: dict[str, Any] = await dialog
+        result = await dialog
         dialog.clear()
 
         if result is None or ctx.readonly:
@@ -615,7 +615,7 @@ class CampaignDetailPage(CMPage[CampaignDetailPageModel]):
             title=f"Editing Manifest {node_name}",
             initial_model=node_manifest,
         )
-        result: dict[str, Any] = await dialog
+        result = await dialog
         dialog.clear()
 
         if result is None or ctx.readonly:

--- a/packages/cm-web/src/lsst/cmservice/web/pages/node_detail.py
+++ b/packages/cm-web/src/lsst/cmservice/web/pages/node_detail.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Any, Self, TypedDict
 
 from httpx import AsyncClient
-from nice_dialog.dialogs.confirmation import ConfirmationDialog
+from nice_dialogs.dialogs import ConfirmationDialog
 from nicegui import app, ui
 from nicegui.events import ClickEventArguments
 from yaml import safe_dump

--- a/packages/cm-web/src/lsst/cmservice/web/pages/node_detail.py
+++ b/packages/cm-web/src/lsst/cmservice/web/pages/node_detail.py
@@ -4,8 +4,12 @@ from functools import partial
 from typing import Any, Self, TypedDict
 
 from httpx import AsyncClient
+from nice_dialog.dialogs.confirmation import ConfirmationDialog
 from nicegui import app, ui
+from nicegui.events import ClickEventArguments
 from yaml import safe_dump
+
+from lsst.cmservice.models.enums import StatusEnum
 
 from .. import api
 from ..components import dialog, storage, strings
@@ -69,6 +73,7 @@ class NodeDetailPage(CMPage[NodeDetailPageModel]):
         self.create_header.refresh()
         return self
 
+    @ui.refreshable_method
     async def node_detail_ribbon(self) -> None:
         """Renders a Node Detail ribbon.
 
@@ -77,7 +82,7 @@ class NodeDetailPage(CMPage[NodeDetailPageModel]):
         and step-advance buttons if available.
         """
         node = self.model["node"]
-        with ui.row().classes("shrink-0 gap-2 w-full"):
+        with ui.row().classes("shrink-0 gap-2 w-full items-center"):
             with ui.link(target=f"/campaign/{node['namespace']}"):
                 ui.chip("Campaign", icon="shape_line", color="white").tooltip(node["namespace"])
             ui.chip(node["kind"], icon="fingerprint", color="white").tooltip("Node Kind")
@@ -135,6 +140,8 @@ class NodeDetailPage(CMPage[NodeDetailPageModel]):
     @ui.refreshable_method
     async def node_status_chip(self) -> None:
         """Renders a chip indicating the Status of the Node."""
+        color: str
+        icon: str
         data = await api.describe_one_node(id=self.node_id)
         self.model["node"] = data["node"]
         node_status = StatusDecorators[data["node"]["status"]]
@@ -142,15 +149,35 @@ class NodeDetailPage(CMPage[NodeDetailPageModel]):
         icon, _ = ui.state(node_status.emoji)
         color, _ = ui.state(node_status.hex)
 
-        # For a breakpoint node, we will show the chip only if it is accepted
-        if self.model["node"]["kind"] != "breakpoint":
-            ui.chip(status, icon=icon, color=color).tooltip("Node Status")
-        else:
-            ui.chip(status, icon=icon, color=color).tooltip("Node Status").bind_visibility_from(
-                target_object=self.model["node"],
-                target_name="status",
-                backward=lambda v: v in ["accepted", "failed"],
-            )
+        match self.model["node"]:
+            case {"kind": "breakpoint"}:
+                ui.chip(status, icon=icon, color=color).tooltip("Node Status").bind_visibility_from(
+                    target_object=self.model,
+                    target_name=("node", "status"),
+                    backward=lambda v: v in ["accepted", "failed"],
+                )
+            case {"kind": "group", "status": ("accepted" | "rejected")}:
+                _toggle = {"accepted": "rejected", "rejected": "accepted"}
+                not_status = _toggle[status]
+                with (
+                    ui.dropdown_button(status, icon=icon, color=color, auto_close=True)
+                    .props("flat")
+                    .classes("q-chip")
+                ):
+                    handler = partial(self.handle_accept_reject, StatusEnum[not_status])
+                    with ui.item(on_click=handler).classes("items-center"):
+                        with ui.item_section().props("avatar"):
+                            ui.icon(
+                                StatusDecorators[not_status].emoji,
+                                color=str(StatusDecorators[not_status].color),
+                            )
+                        with ui.item_section():
+                            if status == "accepted":
+                                ui.label("Reject").classes("font-medium")
+                            elif status == "rejected":
+                                ui.label("Accept").classes("font-medium")
+            case _:
+                ui.chip(status, icon=icon, color=color).tooltip("Node Status")
 
     @ui.refreshable_method
     async def node_activity_timeline(self) -> None:
@@ -289,3 +316,30 @@ class NodeDetailPage(CMPage[NodeDetailPageModel]):
                 on_click=force_method,
             ).tooltip(strings.BREAKPOINT_REJECT_TOOLTIP)
             # TODO refresh element(s) in click callback!
+
+    async def handle_accept_reject(self, desired_state: StatusEnum, e: ClickEventArguments) -> None:
+        """Attempts to toggle an accepted or rejected node into the opposite
+        state.
+        """
+        api_kwargs = {"reject": False, "accept": False, "force": True}
+        if desired_state is StatusEnum.rejected:
+            api_kwargs["reject"] = True
+            confirm_message = strings.GROUP_TOGGLE_REJECT_DETAIL
+        elif desired_state is StatusEnum.accepted:
+            api_kwargs["accept"] = True
+            confirm_message = strings.GROUP_TOGGLE_ACCEPT_DETAIL
+        else:
+            return None
+
+        confirm = ConfirmationDialog(
+            message=confirm_message,
+            show_remember_checkbox=False,
+        )
+        result, _ = await confirm
+        confirm.clear()
+
+        self.show_spinner()
+        if result:
+            await api.retry_restart_node(n0=self.node_id, **api_kwargs)
+            await self.create_content.refresh()
+        self.hide_spinner()

--- a/src/lsst/cmservice/machines/nodes/__init__.py
+++ b/src/lsst/cmservice/machines/nodes/__init__.py
@@ -23,7 +23,7 @@ TRANSITIONS = [
     {"trigger": "block", "source": StatusEnum.running, "dest": StatusEnum.blocked},
     {
         "trigger": "fail",
-        "source": [StatusEnum.waiting, StatusEnum.ready, StatusEnum.running],
+        "source": "*",
         "dest": StatusEnum.failed,
     },
     # User-initiated transitions
@@ -31,7 +31,7 @@ TRANSITIONS = [
     {"trigger": "unblock", "source": StatusEnum.blocked, "dest": StatusEnum.running},
     {"trigger": "resume", "source": StatusEnum.paused, "dest": StatusEnum.running},
     {"trigger": "force", "source": "*", "dest": StatusEnum.accepted},
-    {"trigger": "reject", "source": "*", "dest": StatusEnum.failed},
+    {"trigger": "reject", "source": StatusEnum.accepted, "dest": StatusEnum.rejected},
     # TODO implement a revival trigger for out-of-band recovery of failures
     {"trigger": "revive", "source": StatusEnum.failed, "dest": StatusEnum.running},
     # Inverse transitions, i.e., rollbacks

--- a/src/lsst/cmservice/machines/nodes/group.py
+++ b/src/lsst/cmservice/machines/nodes/group.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections import ChainMap
 from os.path import expandvars
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 from anyio import Path
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from transitions import EventData
 
 from lsst.cmservice.models.enums import ManifestKind, StatusEnum
@@ -90,6 +91,21 @@ class GroupMachine(NodeMachine, FilesystemActionMixin, HTCondorLaunchMixin):
             ("wms_submit_sh.j2", f"{self.db_model.name}.sh"),
         }
 
+    async def finalize_preparation(self, event: EventData) -> None:
+        """Finalize the preparation stage of a Group. This includes applying
+        rendered outputs to critical configuration sections using the config
+        chain.
+        """
+        j_env = ImmutableSandboxedEnvironment()
+        j_env.globals = cast(dict[str, object], self.configuration_chain)
+
+        # Render any butler collection configuration
+        for k, v in self.db_model.configuration["butler"]["collections"].items():
+            # TODO this is not recursive into complex collection lists
+            if not isinstance(v, str):
+                continue
+            self.db_model.configuration["butler"]["collections"][k] = j_env.from_string(v).render()
+
     async def do_prepare(self, event: EventData) -> None:
         """Callback invoked when executing the "prepare" transition."""
 
@@ -103,6 +119,8 @@ class GroupMachine(NodeMachine, FilesystemActionMixin, HTCondorLaunchMixin):
 
         # Render output artifacts
         await self.render_action_templates(event)
+
+        await self.finalize_preparation(event)
 
     async def render_bps_includes(self, event: EventData) -> list[str]:
         """BPS Include files get special treatment here for legacy and pract-

--- a/src/lsst/cmservice/machines/nodes/steps.py
+++ b/src/lsst/cmservice/machines/nodes/steps.py
@@ -18,6 +18,7 @@ from lsst.cmservice.models.lib.graph import (
     graph_from_edge_list_v2,
     insert_node_to_graph,
     subgraph_between_nodes,
+    topographical_sorted_collections,
 )
 from lsst.cmservice.models.lib.timestamp import element_time
 from lsst.cmservice.models.manifest import (
@@ -558,23 +559,21 @@ class StepCollectMachine(NodeMachine, FilesystemActionMixin, HTCondorLaunchMixin
         the simple look-back query to have missing information.
 
         The role of the collect step in a graph is to be the definite exit node
-        from a step's sub network of steps. This means that for any given
+        from a step's subgraph of groups. This means that for any given
         collect node, there will be one and only one step node in its reverse
         path, so if we walk the graph backward from this node along any edge,
-        we will reach the same step node along any of those paths, and each of
-        those paths will have exactly one group node, irrespective of any other
-        nodes along that path, e.g., breakpoints.
+        we will reach the same step node along any of those paths. Likewise,
+        any path by which the collect node is reachable from that step node may
+        traverse one or more groups that belong to that step and no other step.
 
-        This should also mean that for any subnetwork defined between step and
-        collect, the set of groups within that network is complete.
-
-        This points to the idea that on creation, the originating step node
-        for which this collect step is created should be cached as a metadata.
+        When a Step node prepares its initial subgraph, it stamps its own ID on
+        each new node, so the Collect step already has a reference to its Step
+        parent in the graph.
         """
 
-        # construct a graph where the source is the originating step and the
-        # sink is the current collect node. This represents a subgraph of the
-        # entire campaign that contains the network of this step and its groups
+        # construct a subgraph where the source is the originating step and the
+        # sink is the current collect node. This subgraph describes the network
+        # of this step and its groups
         parent_step = self.db_model.metadata_.get("step")
         if parent_step is None:
             raise RuntimeError("Collect node has no ancestor step node")
@@ -583,12 +582,9 @@ class StepCollectMachine(NodeMachine, FilesystemActionMixin, HTCondorLaunchMixin
         graph = await graph_from_edge_list_v2(edges, self.session)
         subgraph = subgraph_between_nodes(graph, UUID(parent_step), self.db_model.id)
 
-        # For every node in the subgraph of kind group, fish out its output
+        # For every node in the sorted subgraph of kind group, find its output
         # collection.
-        groups = [
-            node[1]["model"] for node in subgraph.nodes.data() if node[1]["model"].kind is ManifestKind.group
-        ]
-        self.collections = [group.configuration["butler"]["collections"]["group_output"] for group in groups]
+        self.collections = topographical_sorted_collections(subgraph)
 
         # perform specific preparations
         await self.action_prepare(event)

--- a/src/lsst/cmservice/machines/nodes/steps.py
+++ b/src/lsst/cmservice/machines/nodes/steps.py
@@ -582,9 +582,10 @@ class StepCollectMachine(NodeMachine, FilesystemActionMixin, HTCondorLaunchMixin
         graph = await graph_from_edge_list_v2(edges, self.session)
         subgraph = subgraph_between_nodes(graph, UUID(parent_step), self.db_model.id)
 
-        # For every node in the sorted subgraph of kind group, find its output
-        # collection.
-        self.collections = topographical_sorted_collections(subgraph)
+        # For every node in the sorted subgraph of kind group, find its run
+        # collection in "reverse" order, putting the run collections "closest"
+        # to the collect first.
+        self.collections = topographical_sorted_collections(subgraph, reverse=True)
 
         # perform specific preparations
         await self.action_prepare(event)

--- a/src/lsst/cmservice/machines/tasks.py
+++ b/src/lsst/cmservice/machines/tasks.py
@@ -105,10 +105,12 @@ async def change_node_state(
             trigger = "pause"
         case (StatusEnum.paused, StatusEnum.running):
             trigger = "resume"
-        case (_, StatusEnum.failed):
+        case (StatusEnum.accepted, StatusEnum.rejected):
             trigger = "reject"
         case (_, StatusEnum.accepted):
             trigger = "force" if force else "finish"
+        case (_, StatusEnum.failed):
+            trigger = "fail"
         case _:
             logger.warning(
                 "Invalid node transition requested",

--- a/src/lsst/cmservice/routers/v2/nodes.py
+++ b/src/lsst/cmservice/routers/v2/nodes.py
@@ -274,6 +274,9 @@ async def update_node_resource(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such node")
 
     if use_rfc7396:
+        # With RFC7396, a Node is patched without creating a new version. This
+        # is useful for updating status without affecting config
+        # TODO this should support metadata updates as well.
         if TYPE_CHECKING:
             assert isinstance(patch_data, CampaignUpdate)
         if patch_data.status is None:

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -3,9 +3,10 @@
 import importlib
 import os
 from collections.abc import AsyncGenerator, Callable, Generator
+from contextlib import ExitStack, asynccontextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import NAMESPACE_DNS, uuid4
 
 import pytest
@@ -174,6 +175,41 @@ async def async_client_fixture(
     ) as aclient:
         yield aclient
     app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture(name="web_client", scope="module", loop_scope="module")
+async def mock_client_factory(aclient: AsyncClient) -> AsyncGenerator[AsyncClient]:
+    """Mocks a client factory for cm-web API workflows using an async client
+    with test app transport and modified base_url.
+    """
+    base_url = str(aclient.base_url).strip("/")
+    aclient_ = AsyncClient(
+        follow_redirects=True,
+        transport=aclient._transport,
+        base_url=f"{base_url}/v2",
+    )
+
+    @asynccontextmanager
+    async def aclient_cm() -> AsyncGenerator[AsyncClient]:
+        yield aclient_
+
+    mock_factory = MagicMock()
+    mock_factory.aclient = aclient_cm
+
+    modules_to_patch = [
+        "lsst.cmservice.web.api.activity.CLIENT_FACTORY",
+        "lsst.cmservice.web.api.campaigns.CLIENT_FACTORY",
+        "lsst.cmservice.web.api.manifests.CLIENT_FACTORY",
+        "lsst.cmservice.web.api.nodes.CLIENT_FACTORY",
+        "lsst.cmservice.web.lib.client_factory.CLIENT_FACTORY",
+    ]
+    with ExitStack() as stack:
+        for api_module in modules_to_patch:
+            stack.enter_context(patch(api_module, mock_factory))
+
+        # Mock any app storage
+        stack.enter_context(patch("lsst.cmservice.web.api.campaigns.app", MagicMock()))
+        yield aclient_
 
 
 @pytest_asyncio.fixture(name="daemon_context", scope="module", loop_scope="module")

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -453,8 +453,8 @@ async def test_campaign_groups(aclient: AsyncClient) -> AsyncGenerator[str]:
                     "/path/to/a/duplicate/file.yaml",
                     "${PIPE_DIR}/bps/clustering/include.yaml",
                 ],
-                "extra_qgraph_options": "--dataset-query-constraint finalVisitSummary",
-                "extra_run_quantum_options": "--no-raise-on-partial-outputs",
+                "extra_qgraph_options": ["--dataset-query-constraint finalVisitSummary"],
+                "extra_run_quantum_options": ["--no-raise-on-partial-outputs"],
             },
         },
     )

--- a/tests/v2/test_machines.py
+++ b/tests/v2/test_machines.py
@@ -845,3 +845,70 @@ async def test_group_fail_reset(
     # Assert the artifact directory is deleted
     assert group_artifact_path is not None
     assert not (await Path(group_artifact_path).exists())
+
+
+async def test_group_fail_rescue(
+    test_campaign_groups: str,
+    session: AsyncSession,
+    aclient: AsyncClient,
+    web_client: AsyncClient,
+) -> None:
+    """Tests the rescue action of a failed node.
+
+    This test uses API workflow logic from the cm-web package.
+    """
+    from lsst.cmservice.web.api.rescue import rescue_group
+
+    campaign_id = urlparse(url=test_campaign_groups).path.split("/")[-2:][0]
+
+    # Fetch and prepare a step
+    node_id = uuid5(UUID(campaign_id), "lambert.1")
+    node = await session.get_one(Node, node_id)
+    node_machine = StepMachine(o=node)
+    await node_machine.trigger("prepare")
+
+    # Fetch and prepare a group
+    s = (
+        select(Node)
+        .where(Node.name == "lambert_group_001")
+        .where(Node.namespace == campaign_id)
+        .where(Node.version == 1)
+    )
+
+    group = (await session.exec(s)).one()
+    group_machine = GroupMachine(o=group, initial_state=group.status)
+    await session.commit()
+
+    await group_machine.trigger("prepare")
+    with patch(
+        "lsst.cmservice.machines.node.GroupMachine.do_start",
+        side_effect=RuntimeError("Error: unknown error"),
+    ):
+        await group_machine.trigger("start")
+
+    await session.refresh(group, ["status", "metadata_", "machine"])
+
+    # assert node failed
+    x = await aclient.get(f"/v2/nodes/{group.id}")
+    assert x.is_success
+    assert x.json()["status"] == "failed"
+
+    # ====================
+    # TEST RESCUE WORKFLOW
+    # ====================
+    rescue = await rescue_group(n0=str(group.id))
+
+    # assert details about the rescue
+    x = await aclient.get(f"/v2/nodes/{rescue}")
+    assert x.is_success
+    rescue_group_node: dict = x.json()
+
+    assert "rescue_001" in rescue_group_node["configuration"]["butler"]["collections"]["run"]
+    assert "rescue_001" in rescue_group_node["configuration"]["butler"]["collections"]["group_output"]
+
+    found_skip_option = False
+    for option in rescue_group_node["configuration"]["bps"]["extra_qgraph_options"]:
+        if "skip-existing-in" in option:
+            assert group.configuration["butler"]["collections"]["run"] in option
+            found_skip_option = True
+    assert found_skip_option

--- a/tests/v2/test_node_routes.py
+++ b/tests/v2/test_node_routes.py
@@ -204,3 +204,40 @@ async def test_node_double_update(aclient: AsyncClient) -> None:
     )
     assert not x.is_success
     assert x.status_code == codes.CONFLICT
+
+
+async def test_add_group_as_node(aclient: AsyncClient) -> None:
+    """Tests adding a new Group to an existing campaign using the Node API"""
+    campaign_name = uuid4().hex[:8]
+    node_name = uuid4().hex[:8]
+
+    # Create a campaign
+    x = await aclient.post(
+        "/v2/campaigns",
+        json={
+            "kind": "campaign",
+            "metadata": {"name": campaign_name},
+            "spec": {},
+        },
+    )
+    assert x.is_success
+    campaign_id = x.json()["id"]
+
+    # Create a new campaign node
+    x = await aclient.post(
+        "/v2/nodes",
+        json={
+            "kind": "node",
+            "metadata": {"name": node_name, "namespace": campaign_id, "kind": "group"},
+            "spec": {
+                "bps": {"pipeline_yaml": "${DRP_PIPE_DIR}/pipelines/HSC/DRP-RC2.yaml#step1"},
+                "butler": {},
+                "lsst": {},
+                "wms": {},
+                "site": {},
+            },
+        },
+    )
+    assert x.is_success
+    node = x.json()
+    assert node["version"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1275,6 +1275,7 @@ dependencies = [
     { name = "deepdiff" },
     { name = "lsst-cmservice-models" },
     { name = "networkx" },
+    { name = "nice-dialogs" },
     { name = "nicegui" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1292,7 +1293,8 @@ requires-dist = [
     { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "lsst-cmservice-models", editable = "packages/cm-models" },
     { name = "networkx", specifier = ">=3.5" },
-    { name = "nicegui", specifier = ">=3.8.0" },
+    { name = "nice-dialogs", git = "https://github.com/tcjennings/nice-dialogs?rev=0beec0651fa101576741d2a8cdf7ec5e7c961d59" },
+    { name = "nicegui", specifier = ">=3.11.0" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pydantic-extra-types", specifier = ">=2.10.5" },
     { name = "pydantic-settings", specifier = ">=2.12" },
@@ -1698,6 +1700,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nice-dialogs"
+version = "1.1.0"
+source = { git = "https://github.com/tcjennings/nice-dialogs?rev=0beec0651fa101576741d2a8cdf7ec5e7c961d59#0beec0651fa101576741d2a8cdf7ec5e7c961d59" }
+dependencies = [
+    { name = "nicegui" },
+    { name = "pydantic-extra-types", extra = ["cron"] },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements a Group Rescue workflow for CM Web UI. The rescue creates a new *rescue* group downstream of a failed group with a bps option to "skip-existing-in" the *rescued* group.

To accommodate rescue-chains in a step's subgraph, a collect node now uses a *topographical* sort of a subgraph to ensure group outputs are chained in the correct order.